### PR TITLE
refactor: Block settings tab is now selected when a block is clicked

### DIFF
--- a/packages/form-builder/src/components/sidebar/primary.js
+++ b/packages/form-builder/src/components/sidebar/primary.js
@@ -6,10 +6,9 @@ import TabPanel from './tab-panel';
 import {DonationGoalSettings, FormTitleSettings, OfflineDonationsSettings} from '../../settings';
 import FormFields from "../../settings/form-fields";
 import {PopoutSlot} from "./popout";
-import {useSelect} from "@wordpress/data";
-import {store as blockEditorStore} from "@wordpress/block-editor/build/store";
 import {useState} from "@wordpress/element";
 import {useEffect} from "react";
+import useSelectedBlocks from "../../hooks/useSelectedBlocks";
 
 const {Slot: InspectorSlot, Fill: InspectorFill} = createSlotFill(
     'StandAloneBlockEditorSidebarInspector',
@@ -45,16 +44,7 @@ function Sidebar() {
 
     const [selectedTab, setSelectedTab] = useState(null);
 
-    const {
-        selectedBlocks,
-    } = useSelect(select => {
-        const {
-            getSelectedBlockClientIds,
-        } = select(blockEditorStore);
-        return {
-            selectedBlocks: getSelectedBlockClientIds(),
-        };
-    });
+    const selectedBlocks = useSelectedBlocks();
 
     useEffect(
         () => {

--- a/packages/form-builder/src/components/sidebar/primary.js
+++ b/packages/form-builder/src/components/sidebar/primary.js
@@ -1,12 +1,15 @@
-import {
-    createSlotFill,
-    TabPanel,
-} from '@wordpress/components';
+import {createSlotFill} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
+
+import TabPanel from './tab-panel';
 
 import {DonationGoalSettings, FormTitleSettings, OfflineDonationsSettings} from '../../settings';
 import FormFields from "../../settings/form-fields";
 import {PopoutSlot} from "./popout";
+import {useSelect} from "@wordpress/data";
+import {store as blockEditorStore} from "@wordpress/block-editor/build/store";
+import {useState} from "@wordpress/element";
+import {useEffect} from "react";
 
 const {Slot: InspectorSlot, Fill: InspectorFill} = createSlotFill(
     'StandAloneBlockEditorSidebarInspector',
@@ -40,6 +43,26 @@ const tabs = [
 
 function Sidebar() {
 
+    const [selectedTab, setSelectedTab] = useState(null);
+
+    const {
+        selectedBlocks,
+    } = useSelect(select => {
+        const {
+            getSelectedBlockClientIds,
+        } = select(blockEditorStore);
+        return {
+            selectedBlocks: getSelectedBlockClientIds(),
+        };
+    });
+
+    useEffect(
+        () => {
+            if (selectedBlocks.length) setSelectedTab('block');
+        }
+        , [selectedBlocks], // only run effect when workspaceID changes
+    );
+
     return (
         <div
             className="givewp-next-gen-sidebar givewp-next-gen-sidebar-primary"
@@ -52,6 +75,7 @@ function Sidebar() {
                 className="sidebar-panel"
                 activeClass="active-tab"
                 tabs={tabs}
+                state={[selectedTab, setSelectedTab]}
             >
                 {(tab) => <tab.content />}
             </TabPanel>

--- a/packages/form-builder/src/components/sidebar/primary.js
+++ b/packages/form-builder/src/components/sidebar/primary.js
@@ -60,7 +60,7 @@ function Sidebar() {
         () => {
             if (selectedBlocks.length) setSelectedTab('block');
         }
-        , [selectedBlocks], // only run effect when workspaceID changes
+        , [selectedBlocks], // only run effect when selectedBlocks changes
     );
 
     return (

--- a/packages/form-builder/src/components/sidebar/styles.scss
+++ b/packages/form-builder/src/components/sidebar/styles.scss
@@ -38,7 +38,11 @@
 }
 
 .sidebar-panel .active-tab {
-    border-top: 3px solid #66bb6a;
+    border-bottom: 3px solid #66bb6a;
+}
+
+.sidebar-panel .components-button:focus:not(:disabled) {
+    box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 -4px 0 0 var(--wp-admin-theme-color);
 }
 
 .givewp-next-gen-inspector-popout {

--- a/packages/form-builder/src/components/sidebar/tab-panel.js
+++ b/packages/form-builder/src/components/sidebar/tab-panel.js
@@ -1,0 +1,114 @@
+/**
+ * @note This is a fork of the WordPress component.
+ *
+ * Changes:
+ *  - Update relative component imports.
+ *  - Replace useState hook with injected state for external control of the selected tab.
+ */
+
+import _extends from "@babel/runtime/helpers/esm/extends";
+import {createElement} from "@wordpress/element";
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import {partial, find} from 'lodash';
+/**
+ * WordPress dependencies
+ */
+
+import {/* useState, */ useEffect} from '@wordpress/element';
+import {useInstanceId} from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+
+import {NavigableMenu, Button} from '@wordpress/components';
+// import { NavigableMenu } from '../navigable-container';
+// import Button from '../button';
+
+const noop = () => {
+};
+
+const TabButton = _ref => {
+    let {
+        tabId,
+        onClick,
+        children,
+        selected,
+        ...rest
+    } = _ref;
+    return createElement(Button, _extends({
+        role: "tab",
+        tabIndex: selected ? null : -1,
+        "aria-selected": selected,
+        id: tabId,
+        onClick: onClick,
+    }, rest), children);
+};
+
+export default function TabPanel(_ref2) {
+    var _selectedTab$name;
+
+    let {
+        className,
+        children,
+        tabs,
+        initialTabName,
+        orientation = 'horizontal',
+        activeClass = 'is-active',
+        onSelect = noop,
+        state: [selected, setSelected], /** @note Injecting state for external control of the selected tab. */
+    } = _ref2;
+    const instanceId = useInstanceId(TabPanel, 'tab-panel');
+    // const [selected, setSelected] = useState(null);
+
+    const handleClick = tabKey => {
+        setSelected(tabKey);
+        onSelect(tabKey);
+    };
+
+    const onNavigate = (childIndex, child) => {
+        child.click();
+    };
+
+    const selectedTab = find(tabs, {
+        name: selected,
+    });
+    const selectedId = `${instanceId}-${(_selectedTab$name = selectedTab === null || selectedTab === void 0 ? void 0 : selectedTab.name) !== null && _selectedTab$name !== void 0 ? _selectedTab$name : 'none'}`;
+    useEffect(() => {
+        const newSelectedTab = find(tabs, {
+            name: selected,
+        });
+
+        if (!newSelectedTab) {
+            setSelected(initialTabName || (tabs.length > 0 ? tabs[0].name : null));
+        }
+    }, [tabs]);
+    return createElement("div", {
+        className: className,
+    }, createElement(NavigableMenu, {
+        role: "tablist",
+        orientation: orientation,
+        onNavigate: onNavigate,
+        className: "components-tab-panel__tabs",
+    }, tabs.map(tab => createElement(TabButton, {
+        className: classnames('components-tab-panel__tabs-item', tab.className, {
+            [activeClass]: tab.name === selected,
+        }),
+        tabId: `${instanceId}-${tab.name}`,
+        "aria-controls": `${instanceId}-${tab.name}-view`,
+        selected: tab.name === selected,
+        key: tab.name,
+        onClick: partial(handleClick, tab.name),
+    }, tab.title))), selectedTab && createElement("div", {
+        key: selectedId,
+        "aria-labelledby": selectedId,
+        role: "tabpanel",
+        id: `${selectedId}-view`,
+        className: "components-tab-panel__tab-content",
+    }, children(selectedTab)));
+}
+//# sourceMappingURL=index.js.map

--- a/packages/form-builder/src/components/sidebar/tab-panel.js
+++ b/packages/form-builder/src/components/sidebar/tab-panel.js
@@ -1,9 +1,11 @@
 /**
  * @note This is a fork of the WordPress component.
  *
- * Changes:
- *  - Update relative component imports.
+ * Substantive changes:
  *  - Replace useState hook with injected state for external control of the selected tab.
+ *
+ * Maintenance changes:
+ *  - Update relative component imports for NavigableMenu, Button.
  *  - Disabled eslint rule react-hooks/exhaustive-deps for useEffect in the TabPanel component.
  */
 

--- a/packages/form-builder/src/components/sidebar/tab-panel.js
+++ b/packages/form-builder/src/components/sidebar/tab-panel.js
@@ -4,6 +4,7 @@
  * Changes:
  *  - Update relative component imports.
  *  - Replace useState hook with injected state for external control of the selected tab.
+ *  - Disabled eslint rule react-hooks/exhaustive-deps for useEffect in the TabPanel component.
  */
 
 import _extends from "@babel/runtime/helpers/esm/extends";
@@ -86,7 +87,7 @@ export default function TabPanel(_ref2) {
         if (!newSelectedTab) {
             setSelected(initialTabName || (tabs.length > 0 ? tabs[0].name : null));
         }
-    }, [tabs]);
+    }, [tabs]); // eslint-disable-line react-hooks/exhaustive-deps
     return createElement("div", {
         className: className,
     }, createElement(NavigableMenu, {

--- a/packages/form-builder/src/components/sidebar/tab-panel.js
+++ b/packages/form-builder/src/components/sidebar/tab-panel.js
@@ -5,70 +5,55 @@
  *  - Replace useState hook with injected state for external control of the selected tab.
  *
  * Maintenance changes:
+ *  - Removed import of useState.
  *  - Update relative component imports for NavigableMenu, Button.
  *  - Disabled eslint rule react-hooks/exhaustive-deps for useEffect in the TabPanel component.
  */
-
-import _extends from "@babel/runtime/helpers/esm/extends";
-import {createElement} from "@wordpress/element";
 
 /**
  * External dependencies
  */
 import classnames from 'classnames';
-import {partial, find} from 'lodash';
+import {partial, noop, find} from 'lodash';
+
 /**
  * WordPress dependencies
  */
-
 import {/* useState, */ useEffect} from '@wordpress/element';
 import {useInstanceId} from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-
 import {NavigableMenu, Button} from '@wordpress/components';
-// import { NavigableMenu } from '../navigable-container';
-// import Button from '../button';
 
-const noop = () => {
-};
+const TabButton = ({tabId, onClick, children, selected, ...rest}) => (
+    <Button
+        role="tab"
+        tabIndex={selected ? null : -1}
+        aria-selected={selected}
+        id={tabId}
+        onClick={onClick}
+        {...rest}
+    >
+        {children}
+    </Button>
+);
 
-const TabButton = _ref => {
-    let {
-        tabId,
-        onClick,
-        children,
-        selected,
-        ...rest
-    } = _ref;
-    return createElement(Button, _extends({
-        role: "tab",
-        tabIndex: selected ? null : -1,
-        "aria-selected": selected,
-        id: tabId,
-        onClick: onClick,
-    }, rest), children);
-};
-
-export default function TabPanel(_ref2) {
-    var _selectedTab$name;
-
-    let {
-        className,
-        children,
-        tabs,
-        initialTabName,
-        orientation = 'horizontal',
-        activeClass = 'is-active',
-        onSelect = noop,
-        state: [selected, setSelected], /** @note Injecting state for external control of the selected tab. */
-    } = _ref2;
+export default function TabPanel({
+                                     className,
+                                     children,
+                                     tabs,
+                                     initialTabName,
+                                     orientation = 'horizontal',
+                                     activeClass = 'is-active',
+                                     onSelect = noop,
+                                     state: [selected, setSelected], /** @note Injecting state for external control of the selected tab. */
+                                 }) {
     const instanceId = useInstanceId(TabPanel, 'tab-panel');
-    // const [selected, setSelected] = useState(null);
+    // const [selected, setSelected] = useState(null); /** @note Replaced with injected state. */
 
-    const handleClick = tabKey => {
+    const handleClick = (tabKey) => {
         setSelected(tabKey);
         onSelect(tabKey);
     };
@@ -76,42 +61,56 @@ export default function TabPanel(_ref2) {
     const onNavigate = (childIndex, child) => {
         child.click();
     };
+    const selectedTab = find(tabs, {name: selected});
+    const selectedId = `${instanceId}-${selectedTab?.name ?? 'none'}`;
 
-    const selectedTab = find(tabs, {
-        name: selected,
-    });
-    const selectedId = `${instanceId}-${(_selectedTab$name = selectedTab === null || selectedTab === void 0 ? void 0 : selectedTab.name) !== null && _selectedTab$name !== void 0 ? _selectedTab$name : 'none'}`;
     useEffect(() => {
-        const newSelectedTab = find(tabs, {
-            name: selected,
-        });
-
+        const newSelectedTab = find(tabs, {name: selected});
         if (!newSelectedTab) {
-            setSelected(initialTabName || (tabs.length > 0 ? tabs[0].name : null));
+            setSelected(
+                initialTabName || (tabs.length > 0 ? tabs[0].name : null),
+            );
         }
     }, [tabs]); // eslint-disable-line react-hooks/exhaustive-deps
-    return createElement("div", {
-        className: className,
-    }, createElement(NavigableMenu, {
-        role: "tablist",
-        orientation: orientation,
-        onNavigate: onNavigate,
-        className: "components-tab-panel__tabs",
-    }, tabs.map(tab => createElement(TabButton, {
-        className: classnames('components-tab-panel__tabs-item', tab.className, {
-            [activeClass]: tab.name === selected,
-        }),
-        tabId: `${instanceId}-${tab.name}`,
-        "aria-controls": `${instanceId}-${tab.name}-view`,
-        selected: tab.name === selected,
-        key: tab.name,
-        onClick: partial(handleClick, tab.name),
-    }, tab.title))), selectedTab && createElement("div", {
-        key: selectedId,
-        "aria-labelledby": selectedId,
-        role: "tabpanel",
-        id: `${selectedId}-view`,
-        className: "components-tab-panel__tab-content",
-    }, children(selectedTab)));
+
+    return (
+        <div className={className}>
+            <NavigableMenu
+                role="tablist"
+                orientation={orientation}
+                onNavigate={onNavigate}
+                className="components-tab-panel__tabs"
+            >
+                {tabs.map((tab) => (
+                    <TabButton
+                        className={classnames(
+                            'components-tab-panel__tabs-item',
+                            tab.className,
+                            {
+                                [activeClass]: tab.name === selected,
+                            },
+                        )}
+                        tabId={`${instanceId}-${tab.name}`}
+                        aria-controls={`${instanceId}-${tab.name}-view`}
+                        selected={tab.name === selected}
+                        key={tab.name}
+                        onClick={partial(handleClick, tab.name)}
+                    >
+                        {tab.title}
+                    </TabButton>
+                ))}
+            </NavigableMenu>
+            {selectedTab && (
+                <div
+                    key={selectedId}
+                    aria-labelledby={selectedId}
+                    role="tabpanel"
+                    id={`${selectedId}-view`}
+                    className="components-tab-panel__tab-content"
+                >
+                    {children(selectedTab)}
+                </div>
+            )}
+        </div>
+    );
 }
-//# sourceMappingURL=index.js.map

--- a/packages/form-builder/src/hooks/useSelectedBlocks.js
+++ b/packages/form-builder/src/hooks/useSelectedBlocks.js
@@ -1,0 +1,19 @@
+import {useSelect} from "@wordpress/data";
+import {store as blockEditorStore} from "@wordpress/block-editor/build/store";
+
+const useSelectedBlocks = () => {
+    const {
+        selectedBlocks,
+    } = useSelect(select => {
+        const {
+            getSelectedBlockClientIds,
+        } = select(blockEditorStore);
+        return {
+            selectedBlocks: getSelectedBlockClientIds(),
+        };
+    });
+
+    return selectedBlocks
+};
+
+export default useSelectedBlocks;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #30

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR forks the `TabPanel` component from `@wordpress/components` so that the selected tab can be changed from outside of the component. Specifically, this injects the return value of `useState` as a prop to replace the internal use of `useState`.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![Peek 2022-07-26 18-20](https://user-images.githubusercontent.com/10858303/181122254-1bf75c9c-25a4-4187-a725-b5610a634854.gif)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Open the Form Builder
- The "Form" settings tab should be selected by default
- Click on a block in the BlockList
- The "Block" settings tab should now be selected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

