### PR TITLE
Feature: add company field persistence to next-gen form

### DIFF
--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/Block.php
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/Block.php
@@ -129,12 +129,6 @@ class Block
             Hidden::make('formId')
                 ->defaultValue($formId),
 
-            Hidden::make('formTitle')
-                ->defaultValue('Give Next Gen Form'),
-
-            Hidden::make('userId')
-                ->defaultValue(get_current_user_id()),
-
             Hidden::make('currency')
                 ->defaultValue(give_get_currency($formId))
         );
@@ -194,6 +188,8 @@ class Block
             $node = Email::make('email')->required()->emailTag('email');
         } elseif ($block->name === "custom-block-editor/donation-summary") {
             $node = DonationSummary::make('donation-summary');
+        } elseif ($block->name === "custom-block-editor/company-field") {
+            $node = Text::make('company');
         } else {
             $node = Text::make($block->clientId);
         }

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/form/Form.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/form/Form.tsx
@@ -33,8 +33,7 @@ const schema = Joi.object({
     gatewayId: Joi.string().required().label('Payment Gateway').messages(messages),
     formId: Joi.number().required(),
     currency: Joi.string().required(),
-    formTitle: Joi.string().required(),
-    userId: Joi.number().required(),
+    company: Joi.string().optional()
 }).unknown();
 
 const handleSubmitRequest = async (values, setError, gateway: Gateway) => {

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/form/Form.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/form/Form.tsx
@@ -33,7 +33,7 @@ const schema = Joi.object({
     gatewayId: Joi.string().required().label('Payment Gateway').messages(messages),
     formId: Joi.number().required(),
     currency: Joi.string().required(),
-    company: Joi.string().optional()
+    company: Joi.string().optional().allow(null, '')
 }).unknown();
 
 const handleSubmitRequest = async (values, setError, gateway: Gateway) => {

--- a/src/NextGen/DonationForm/DataTransferObjects/DonateFormData.php
+++ b/src/NextGen/DonationForm/DataTransferObjects/DonateFormData.php
@@ -47,6 +47,10 @@ class DonateFormData
      * @var string
      */
     public $formTitle;
+    /**
+     * @var string|null
+     */
+    public $company;
 
     /**
      * Convert data from request into DTO
@@ -66,9 +70,10 @@ class DonateFormData
         $self->firstName = $request['firstName'];
         $self->lastName = $request['lastName'];
         $self->email = $request['email'];
-        $self->wpUserId = (int)$request['userId'];
+        $self->wpUserId = get_current_user_id();
         $self->formId = (int)$request['formId'];
-        $self->formTitle = $request['formTitle'];
+        $self->formTitle = get_the_title($request['formId']);
+        $self->company = !empty($request['company']) ? $request['company'] : null;
 
         return $self;
     }
@@ -88,6 +93,7 @@ class DonateFormData
             'email' => $this->email,
             'formId' => $this->formId,
             'formTitle' => $this->formTitle,
+            'company' => $this->company
         ]);
     }
 }

--- a/src/NextGen/DonationForm/Routes/DonateRoute.php
+++ b/src/NextGen/DonationForm/Routes/DonateRoute.php
@@ -63,7 +63,7 @@ class DonateRoute
             $postData = json_decode($request, true);
 
             // create DTO from POST request
-            $formData = DonateFormData::fromRequest($postData);
+            $formData = DonateFormData::fromRequest(give_clean($postData));
 
             // get all registered gateways
             $paymentGateways = $this->paymentGatewayRegister->getPaymentGateways();


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds persistence support for the company field on the next-gen donation form.  Since there is currently no option to specify if the field is required right now in the form-builder, we'll assume it's optional until we add that functionality.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The donation form
- Removed a couple unnecessary hidden fields as well

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Make sure GiveWP develop branch is up to date
- In next-gen run `npm run dev`
- Create a next-gen form with a company field
- Donate using that form and fill in company field
- Make sure that field is recorded within a donation record in the back-end

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

