### PR TITLE
Feature: Add Payment Gateways block and make section act normal

### DIFF
--- a/src/Framework/FieldsAPI/PaymentGateways.php
+++ b/src/Framework/FieldsAPI/PaymentGateways.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Framework\FieldsAPI;
+
+class PaymentGateways extends Field
+{
+    public function getNodeType(): string
+    {
+        return 'layout';
+    }
+
+    public function getType(): string
+    {
+        return 'gateways';
+    }
+}

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/Block.php
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/Block.php
@@ -12,6 +12,7 @@ use Give\Framework\FieldsAPI\Exceptions\TypeNotSupported;
 use Give\Framework\FieldsAPI\Form;
 use Give\Framework\FieldsAPI\Hidden;
 use Give\Framework\FieldsAPI\Name;
+use Give\Framework\FieldsAPI\PaymentGateways;
 use Give\Framework\FieldsAPI\Radio;
 use Give\Framework\FieldsAPI\Section;
 use Give\Framework\FieldsAPI\Select;
@@ -108,11 +109,6 @@ class Block
      */
     private function createForm(int $formId): Form
     {
-        $gatewayOptions = [];
-        foreach ($this->getEnabledPaymentGateways($formId) as $gateway) {
-            $gatewayOptions[] = Radio::make($gateway->getId())->label($gateway->getPaymentMethodLabel());
-        }
-
         $donationForm = new Form($formId);
 
         $formBlockData = json_decode(get_post($formId)->post_content, false);
@@ -123,8 +119,6 @@ class Block
 
         /** @var Section $paymentDetails */
         $paymentDetails = $donationForm->getNodeByName('payment-details');
-
-        $paymentDetails->append(...$gatewayOptions);
 
         $paymentDetails->append(
             Hidden::make('formId')
@@ -204,6 +198,8 @@ class Block
             });
         } elseif ($block->name === "custom-block-editor/email-field") {
             $node = Email::make('email')->emailTag('email');
+        } elseif ($block->name === "custom-block-editor/payment-gateways") {
+            $node = PaymentGateways::make('gateways');
         } elseif ($block->name === "custom-block-editor/donation-summary") {
             $node = DonationSummary::make('donation-summary');
         } elseif ($block->name === "custom-block-editor/company-field") {

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/fields/SectionNode.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/fields/SectionNode.tsx
@@ -1,22 +1,26 @@
 import {isElement, isField, isGroup, Node} from '@givewp/forms/types';
-import FieldNode from "./FieldNode";
-import ElementNode from "./ElementNode";
-import GroupNode from "./GroupNode";
+import FieldNode from './FieldNode';
+import ElementNode from './ElementNode';
+import GroupNode from './GroupNode';
+import {getGatewaysTemplate} from '../templates';
 
 /**
  * Determine which node template to render
  *
  * @unreleased
  */
-export default function SectionNode({node}: { node: Node }) {
+export default function SectionNode({node}: {node: Node}) {
     if (isField(node)) {
-        return <FieldNode node={node}/>
+        return <FieldNode node={node} />;
     } else if (isElement(node)) {
-        return <ElementNode node={node}/>
+        return <ElementNode node={node} />;
     } else if (isGroup(node)) {
-        return <GroupNode node={node}/>
+        return <GroupNode node={node} />;
+    } else if (node.type === 'gateways') {
+        const Gateways = getGatewaysTemplate();
+
+        return <Gateways />;
     } else {
         return null;
     }
 }
-

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/form/Form.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/form/Form.tsx
@@ -9,9 +9,9 @@ import {useGiveDonationFormStore} from '../store';
 import type {Gateway, Section} from '@givewp/forms/types';
 import postData from '../utilities/postData';
 import {getFormTemplate, getSectionTemplate} from '../templates';
-import {useCallback} from "react";
-import PaymentDetails from "../fields/PaymentDetails";
-import SectionNode from "../fields/SectionNode";
+import {useCallback} from 'react';
+import PaymentDetails from '../fields/PaymentDetails';
+import SectionNode from '../fields/SectionNode';
 
 window.givewp.form = {
     useFormContext,
@@ -33,7 +33,7 @@ const schema = Joi.object({
     gatewayId: Joi.string().required().label('Payment Gateway').messages(messages),
     formId: Joi.number().required(),
     currency: Joi.string().required(),
-    company: Joi.string().optional().allow(null, '')
+    company: Joi.string().optional().allow(null, ''),
 }).unknown();
 
 const handleSubmitRequest = async (values, setError, gateway: Gateway) => {
@@ -75,12 +75,7 @@ export default function Form({defaultValues, sections}: PropTypes) {
         resolver: joiResolver(schema),
     });
 
-    const {
-        handleSubmit,
-        setError,
-        getValues,
-        control
-    } = methods;
+    const {handleSubmit, setError, getValues, control} = methods;
 
     const {errors, isSubmitting, isSubmitSuccessful} = useFormState({control});
 
@@ -117,13 +112,11 @@ export default function Form({defaultValues, sections}: PropTypes) {
             >
                 <>
                     {sections.map((section) => {
-                        if (section.name === 'payment-details') {
-                            return <PaymentDetails gateways={gateways} key={section.name} {...section} />;
-                        }
-
                         return (
                             <FormSectionTemplate key={section.name} section={section}>
-                                {section.nodes.map((node) => <SectionNode key={node.name} node={node}/>)}
+                                {section.nodes.map((node) => (
+                                    <SectionNode key={node.name} node={node} />
+                                ))}
                             </FormSectionTemplate>
                         );
                     })}

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/elements/DonationSummary.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/elements/DonationSummary.tsx
@@ -1,5 +1,5 @@
-import {useMemo} from "react";
-import {__} from "@wordpress/i18n";
+import {useMemo} from 'react';
+import {__} from '@wordpress/i18n';
 
 export default function DonationSummary() {
     const {useWatch} = window.givewp.form;
@@ -12,23 +12,25 @@ export default function DonationSummary() {
                 currency: currency,
             }),
         [currency, navigator.language]
-    )
-
-    return (
-        <ul className="givewp-elements-donationSummary__list">
-            <LineItem label={__('Payment Amount', 'give')} value={formatter.format(Number(amount))}/>
-            <LineItem label={__('Giving Frequency', 'give')} value={__('One time', 'give')}/>
-            <LineItem label={__('Donation Total', 'give')} value={formatter.format(Number(amount))}/>
-        </ul>
     );
 
+    return (
+        <>
+            <strong>Donation Summary</strong>
+            <ul className="givewp-elements-donationSummary__list">
+                <LineItem label={__('Payment Amount', 'give')} value={formatter.format(Number(amount))} />
+                <LineItem label={__('Giving Frequency', 'give')} value={__('One time', 'give')} />
+                <LineItem label={__('Donation Total', 'give')} value={formatter.format(Number(amount))} />
+            </ul>
+        </>
+    );
 }
 
-const LineItem = ({label, value}: { label: string, value: string }) => {
+const LineItem = ({label, value}: {label: string; value: string}) => {
     return (
         <li className="givewp-elements-donationSummary__list-item">
             <div>{label}</div>
             <div>{value}</div>
         </li>
-    )
-}
+    );
+};

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/Amount.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/Amount.tsx
@@ -33,7 +33,11 @@ export default function Amount({name, label, inputProps, levels, allowCustomAmou
                 {label}
                 <input type={allowCustomAmount ? 'text' : 'hidden'} {...inputProps} />
             </label>
-            {fieldError && <p>{fieldError}</p>}
+            {fieldError && (
+                <div className="error-message">
+                    <p role="alert">{fieldError}</p>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/Email.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/Email.tsx
@@ -4,11 +4,13 @@ export default function Email({label, fieldError, inputProps}: FieldProps) {
     return (
         <label>
             <span>{label}</span>
-            <input type="email" aria-invalid={fieldError ? "true" : "false"} {...inputProps} />
+            <input type="email" aria-invalid={fieldError ? 'true' : 'false'} {...inputProps} />
 
-            <div className="error-message">
-                {fieldError && <p role="alert">{fieldError}</p>}
-            </div>
+            {fieldError && (
+                <div className="error-message">
+                    <p role="alert">{fieldError}</p>
+                </div>
+            )}
         </label>
     );
 }

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/Text.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/Text.tsx
@@ -4,11 +4,13 @@ export default function Text({label, fieldError, inputProps}: FieldProps) {
     return (
         <label>
             <span>{label}</span>
-            <input type="text" aria-invalid={fieldError ? "true" : "false"} {...inputProps} />
+            <input type="text" aria-invalid={fieldError ? 'true' : 'false'} {...inputProps} />
 
-            <div className="error-message">
-                {fieldError && <p role="alert">{fieldError}</p>}
-            </div>
+            {fieldError && (
+                <div className="error-message">
+                    <p role="alert">{fieldError}</p>
+                </div>
+            )}
         </label>
     );
 }

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/TextArea.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/fields/TextArea.tsx
@@ -5,7 +5,11 @@ export default function TextArea({label, fieldError, inputProps}: FieldProps) {
         <label>
             {label}
             <textarea {...inputProps} />
-            {fieldError && <p>{fieldError}</p>}
+            {fieldError && (
+                <div className="error-message">
+                    <p role="alert">{fieldError}</p>
+                </div>
+            )}
         </label>
     );
 }

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/index.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/index.tsx
@@ -7,28 +7,33 @@ import TextAreaField from './fields/TextArea';
 import EmailField from './fields/Email';
 import HiddenField from './fields/Hidden';
 import HtmlElement from './elements/Html';
-import DonationSummaryElement from './elements/DonationSummary'
+import DonationSummaryElement from './elements/DonationSummary';
 import NameGroup from './groups/Name';
 import SectionLayout, {SectionProps} from './layouts/Section';
 import Form, {FormProps} from './layouts/Form';
 import AmountField from './fields/Amount';
-import classNames from "classnames";
+import classNames from 'classnames';
+import Gateways from './layouts/Gateways';
 
 export function NodeWrapper({
-                                type,
-                                nodeType,
-                                htmlTag: Element = 'div',
-                                name,
-                                children,
-                            }: { type: string; nodeType: string; htmlTag?: ElementType; name?: string; children: ReactNode }) {
+    type,
+    nodeType,
+    htmlTag: Element = 'div',
+    name,
+    children,
+}: {
+    type: string;
+    nodeType: string;
+    htmlTag?: ElementType;
+    name?: string;
+    children: ReactNode;
+}) {
     return (
-        <Element className={
-            classNames(
-                `givewp-${nodeType}`,
-                `givewp-${nodeType}-${type}`,
-                {[`givewp-${nodeType}-${type}-${name}`]: name},
-            )
-        }>
+        <Element
+            className={classNames(`givewp-${nodeType}`, `givewp-${nodeType}-${type}`, {
+                [`givewp-${nodeType}-${type}-${name}`]: name,
+            })}
+        >
             {children}
         </Element>
     );
@@ -62,6 +67,7 @@ const defaultTemplate = {
     layouts: {
         section: SectionLayout,
         form: Form,
+        gateways: Gateways,
     },
 };
 
@@ -70,24 +76,26 @@ const activeTemplate = window.givewp.template.get();
 const template = {
     fields: {
         ...defaultTemplate.fields,
-        ...activeTemplate?.fields
+        ...activeTemplate?.fields,
     },
     elements: {
         ...defaultTemplate.elements,
-        ...activeTemplate?.elements
+        ...activeTemplate?.elements,
     },
     groups: {
         ...defaultTemplate.groups,
-        ...activeTemplate?.groups
+        ...activeTemplate?.groups,
     },
     layouts: {
         ...defaultTemplate.layouts,
-        ...activeTemplate?.layouts
+        ...activeTemplate?.layouts,
     },
-}
+};
 
 function getTemplate<NodeProps>(type: string, section: string, htmlTag?: string): FC<NodeProps> {
-    const Node = template[section].hasOwnProperty(type) ? withWrapper(template[section][type], section, type, htmlTag) : null;
+    const Node = template[section].hasOwnProperty(type)
+        ? withWrapper(template[section][type], section, type, htmlTag)
+        : null;
 
     let FilteredNode = applyFilters(`givewp/form/${section}/${type}`, Node);
     FilteredNode = applyFilters(`givewp/form/${section}`, Node, type);
@@ -117,6 +125,10 @@ export function getSectionTemplate(): FC<SectionProps> {
 
 export function getFormTemplate(): FC<FormProps> {
     return getTemplate<FormProps>('form', 'layouts');
+}
+
+export function getGatewaysTemplate(): FC {
+    return getTemplate('gateways', 'layouts');
 }
 
 function nodeIsFunctionalComponent(Node: unknown): Node is FC {

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/layouts/Gateways.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/layouts/Gateways.tsx
@@ -1,0 +1,25 @@
+import {useFormState} from 'react-hook-form';
+import {ErrorMessage} from '@hookform/error-message';
+import {useGiveDonationFormStore} from '../../store';
+import PaymentGatewayOption from '../../fields/PaymentGatewayOption';
+
+export default function Gateways() {
+    const {errors} = useFormState();
+    const {gateways} = useGiveDonationFormStore();
+
+    return (
+        <>
+            <ul style={{listStyleType: 'none', padding: 0}}>
+                {gateways.map((gateway, index) => (
+                    <PaymentGatewayOption gateway={gateway} index={index} key={gateway.id} />
+                ))}
+            </ul>
+
+            <ErrorMessage
+                errors={errors}
+                name={'gatewayId'}
+                render={({message}) => <span className="give-next-gen__error-message">{message}</span>}
+            />
+        </>
+    );
+}

--- a/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_donation-summary.scss
+++ b/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_donation-summary.scss
@@ -1,12 +1,24 @@
 .givewp-elements-donationSummary {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.5rem;
+    margin-top: 2rem;
+    background-color: #f2f2f2;
+
+    & > strong {
+        font-size: clamp(1.25rem, 0.8rem + 1.3vw, 1.5rem);
+        font-weight: 400;
+    }
+
     &__list {
         list-style-type: none;
 
         &-item {
             display: flex;
-            padding: 15px 0;
+            padding: 1rem 0;
             justify-content: space-between;
-            border-block-start: 0.0625rem solid #ddd;
+            border-block-start: 0.0625rem solid #ccc;
 
             &:last-child {
                 font-weight: bold;

--- a/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_gateways.scss
+++ b/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_gateways.scss
@@ -1,4 +1,4 @@
-.givewp-layouts-section-payment-gateways {
+.givewp-layouts-gateways {
     ul {
         display: flex;
         flex-direction: column;

--- a/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_inputs.scss
+++ b/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_inputs.scss
@@ -14,6 +14,10 @@
     flex-basis: 15%;
 }
 
+.givewp-fields-hidden {
+    display: none;
+}
+
 input[type="text"]:not([name="amount"]), input[type="email"] {
     border-width: 0.078rem;
     border-style: solid;

--- a/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_sections.scss
+++ b/src/NextGen/DonationForm/FormTemplates/ClassicFormTemplate/css/_sections.scss
@@ -36,3 +36,9 @@
         }
     }
 }
+
+.givewp-section-nodes {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}


### PR DESCRIPTION
## Description

Up to this point the "payment details" section was special. It didn't actually conform to what the Form Builder did, as it was uniquely identified and rendered in the form code. In part, this was because there was no Payment Gateway block.

This PR introduces the Payment Gateway block and template, and normalizes how the section functions. Very likely we'll want to adjust how the template works in the future, as it currently relies on hooks that make it hard to override, but this is good enough for now. It's more important to get the section working normally so there isn't a disconnect between itself and the Form Builder.

We are still adding a couple hidden fields to that section. We'll want to move these at some point and determine where/how we'd like to add those critical fields.

Lastly, I took a moment to clean up some Classic template styles and make the Donation Summary look more like the original design.

## Affects

The payment details section as a whole, really. Also, stylistically, I tweaked all sections for the Classic template to improve spacing between fields.

## Visuals

<img width="864" alt="image" src="https://user-images.githubusercontent.com/2024145/185211198-6ec69574-21b8-47dc-a467-591ab89853af.png">

## Testing Instructions

Check that adding fields to the payments section now works, as well as moving things around.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

