### PR TITLE
Feature: add paragraph element

### DIFF
--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -109,6 +109,11 @@
     }
 }
 
+[data-type="custom-block-editor/paragraph"] .rich-text {
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
 .block-editor-block-list__block .block-list-appender {
     position: unset !important;
 }

--- a/packages/form-builder/src/blocks/elements/index.js
+++ b/packages/form-builder/src/blocks/elements/index.js
@@ -1,0 +1,8 @@
+import paragraph from './paragraph.tsx';
+
+const ElementBlocks = [paragraph];
+
+const blockNames = ElementBlocks.map((block) => block.name);
+
+export default ElementBlocks;
+export {blockNames};

--- a/packages/form-builder/src/blocks/elements/paragraph.tsx
+++ b/packages/form-builder/src/blocks/elements/paragraph.tsx
@@ -1,0 +1,60 @@
+import {__} from '@wordpress/i18n';
+import {RichText, RichTextToolbarButton} from '@wordpress/block-editor';
+import {Icon} from '@wordpress/icons';
+
+const paragraph = {
+    name: 'custom-block-editor/paragraph',
+    category: 'content',
+    settings: {
+        title: __('Paragraph', 'custom-block-editor'),
+        supports: {
+            html: false,
+            multiple: true,
+        },
+        attributes: {
+            content: {
+                type: 'string',
+                source: 'html',
+                default: '',
+            },
+        },
+        icon: () => (
+            <Icon
+                icon={
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <line x1="14.917" y1="20" x2="14.917" y2="4.88889" stroke="#1E1E1E" strokeWidth="1.5" />
+                        <line x1="10.4727" y1="20" x2="10.4727" y2="4.88889" stroke="#1E1E1E" strokeWidth="1.5" />
+                        <line x1="18.333" y1="4.75" x2="9.44412" y2="4.75" stroke="#1E1E1E" strokeWidth="1.5" />
+                        <path
+                            d="M9.13889 8.88889V12.96C7.21109 12.6071 5.75 10.9186 5.75 8.88889C5.75 6.85914 7.21109 5.17065 9.13889 4.81778V8.88889Z"
+                            fill="#1E1E1E"
+                            stroke="#1E1E1E"
+                            strokeWidth="1.5"
+                        />
+                    </svg>
+                }
+            />
+        ),
+        edit: ({attributes, setAttributes}) => {
+            const {content} = attributes;
+            return (
+                <>
+                    <div>
+                        <RichText
+                            tagName="p"
+                            value={content}
+                            allowedFormats={['core/bold', 'core/italic', 'core/link']}
+                            onChange={(value) => setAttributes({content: value})}
+                            placeholder={__('Enter some text', 'custom-block-editor')}
+                        />
+                    </div>
+                </>
+            );
+        },
+        save: function () {
+            return null;
+        },
+    },
+};
+
+export default paragraph;

--- a/packages/form-builder/src/blocks/elements/paragraph.tsx
+++ b/packages/form-builder/src/blocks/elements/paragraph.tsx
@@ -1,5 +1,5 @@
 import {__} from '@wordpress/i18n';
-import {RichText, RichTextToolbarButton} from '@wordpress/block-editor';
+import {RichText} from '@wordpress/block-editor';
 import {Icon} from '@wordpress/icons';
 
 const paragraph = {

--- a/packages/form-builder/src/components/sidebar/panels/field-types-list.js
+++ b/packages/form-builder/src/components/sidebar/panels/field-types-list.js
@@ -1,69 +1,80 @@
-import {useSelect} from "@wordpress/data";
-import {store as blockEditorStore} from "@wordpress/block-editor/build/store";
-import fieldBlocks from "../../../blocks/fields";
-import {__} from "@wordpress/i18n";
-import BlockTypesList from "../../forks/block-types-list";
-import {SearchControl} from "@wordpress/components";
-import {useState} from "react";
+import {useSelect} from '@wordpress/data';
+import {store as blockEditorStore} from '@wordpress/block-editor/build/store';
+import fieldBlocks from '../../../blocks/fields';
+import elementBlocks from '../../../blocks/elements';
+import {__} from '@wordpress/i18n';
+import BlockTypesList from '../../forks/block-types-list';
+import {SearchControl} from '@wordpress/components';
+import {useState} from 'react';
 
 const FieldTypesList = () => {
-
     const [searchValue, setSearchValue] = useState('');
 
-    const store = useSelect(select => {
+    const store = useSelect((select) => {
         return select(blockEditorStore);
     });
 
-    const blocksInUse = store.getBlocks().map(block => {
-        return block.innerBlocks.map(innerBlock => innerBlock.name).flat();
-    }).flat();
+    const blocksInUse = store
+        .getBlocks()
+        .map((block) => {
+            return block.innerBlocks.map((innerBlock) => innerBlock.name).flat();
+        })
+        .flat();
 
-    const blocks = fieldBlocks.map(blockData => {
+    const blocks = [...fieldBlocks, ...elementBlocks].map((blockData) => {
         return {
-            "id": blockData.name,
-            "name": blockData.name,
-            "category": blockData.category,
-            "title": blockData.settings.title,
-            "icon": {
-                "src": blockData.settings.icon ?? "block-default",
+            id: blockData.name,
+            name: blockData.name,
+            category: blockData.category,
+            title: blockData.settings.title,
+            icon: {
+                src: blockData.settings.icon ?? 'block-default',
             },
-            "isDisabled": !(blockData.settings.supports.multiple ?? true) && blocksInUse.includes(blockData.name),
+            isDisabled: !(blockData.settings.supports.multiple ?? true) && blocksInUse.includes(blockData.name),
             // "frecency": ?, // Note: This is not FreQuency, but rather FreCency with combines Frequency with Recency for search ranking.
         };
     });
 
-    const blocksFiltered = blocks.filter(block => block.name.includes(searchValue.toLowerCase().replace(' ', '-')));
+    const blocksFiltered = blocks.filter((block) => block.name.includes(searchValue.toLowerCase().replace(' ', '-')));
 
-    const blocksBySection = blocksFiltered.reduce((sections, block) => {
-        sections[block.category].blocks.push(block);
-        return sections;
-    }, {
-        // @todo: Figure out how to handle third-party (or add-on) field categories.
-        input: {name: 'input', label: __('Input Fields', 'give'), blocks: []},
-        custom: {name: 'custom', label: __('Custom Fields', 'give'), blocks: []},
-    });
+    const blocksBySection = blocksFiltered.reduce(
+        (sections, block) => {
+            sections[block.category].blocks.push(block);
+            return sections;
+        },
+        {
+            // @todo: Figure out how to handle third-party (or add-on) field categories.
+            content: {name: 'content', label: __('Content & Media', 'give'), blocks: []},
+            input: {name: 'input', label: __('Input Fields', 'give'), blocks: []},
+            custom: {name: 'custom', label: __('Custom Fields', 'give'), blocks: []},
+        }
+    );
 
     return (
         <>
             <div style={{margin: '20px'}}>
                 <SearchControl value={searchValue} onChange={setSearchValue} />
             </div>
-            {Object.values(blocksBySection).filter(section => section.blocks.length).map(({name, label, blocks}) => {
-                return (
-                    <>
-                        <h3 style={{
-                            color: 'var( --give-gray-50 )',
-                            margin: '20px',
-                            textTransform: 'uppercase',
-                            fontSize: '.8em',
-                            fontWeight: 500,
-                        }}>
-                            {label}
-                        </h3>
-                        <BlockTypesList key={name} items={blocks} />
-                    </>
-                );
-            })}
+            {Object.values(blocksBySection)
+                .filter((section) => section.blocks.length)
+                .map(({name, label, blocks}) => {
+                    return (
+                        <>
+                            <h3
+                                style={{
+                                    color: 'var( --give-gray-50 )',
+                                    margin: '20px',
+                                    textTransform: 'uppercase',
+                                    fontSize: '.8em',
+                                    fontWeight: 500,
+                                }}
+                            >
+                                {label}
+                            </h3>
+                            <BlockTypesList key={name} items={blocks} />
+                        </>
+                    );
+                })}
         </>
     );
 };

--- a/packages/form-builder/src/index.js
+++ b/packages/form-builder/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {registerBlockType} from "@wordpress/blocks";
+import {registerBlockType} from '@wordpress/blocks';
 
 import './index.scss';
 
@@ -9,17 +9,17 @@ import App from './App';
 import sectionBlocks, {sectionBlockNames} from './blocks/section';
 
 import fieldBlocks from './blocks/fields';
+import elementBlocks from './blocks/elements';
 
 sectionBlocks.map(({name, settings}) => registerBlockType(name, settings));
 
-fieldBlocks.map(({name, settings}) => registerBlockType(name, {
-    ...settings,
-    parent: sectionBlockNames,
-}));
+[...fieldBlocks, ...elementBlocks].map(({name, settings}) =>
+    registerBlockType(name, {...settings, parent: sectionBlockNames})
+);
 
 ReactDOM.render(
     <React.StrictMode>
         <App />
     </React.StrictMode>,
-    document.getElementById('root'),
+    document.getElementById('root')
 );

--- a/src/Framework/FieldsAPI/Paragraph.php
+++ b/src/Framework/FieldsAPI/Paragraph.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Framework\FieldsAPI;
+
+class Paragraph extends Element
+{
+    const TYPE = 'paragraph';
+
+    protected $content = '';
+
+    public function content(string $content): self
+    {
+        $this->content = $content;
+        return $this;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/Block.php
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/Block.php
@@ -12,6 +12,7 @@ use Give\Framework\FieldsAPI\Exceptions\TypeNotSupported;
 use Give\Framework\FieldsAPI\Form;
 use Give\Framework\FieldsAPI\Hidden;
 use Give\Framework\FieldsAPI\Name;
+use Give\Framework\FieldsAPI\Paragraph;
 use Give\Framework\FieldsAPI\PaymentGateways;
 use Give\Framework\FieldsAPI\Radio;
 use Give\Framework\FieldsAPI\Section;
@@ -196,6 +197,9 @@ class Block
                     $group->remove('honorific');
                 }
             });
+        } elseif ($block->name === "custom-block-editor/paragraph") {
+            $node = Paragraph::make(substr(md5(mt_rand()), 0, 7))
+                ->content($block->attributes->content);
         } elseif ($block->name === "custom-block-editor/email-field") {
             $node = Email::make('email')->emailTag('email');
         } elseif ($block->name === "custom-block-editor/payment-gateways") {

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/elements/Paragraph.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/elements/Paragraph.tsx
@@ -1,0 +1,9 @@
+import {ElementProps} from '@givewp/forms/propTypes';
+
+interface ParagraphProps extends ElementProps {
+    content: string;
+}
+
+export default function Paragraph({content}: ParagraphProps) {
+    return <p>{content}</p>;
+}

--- a/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/index.tsx
+++ b/src/NextGen/DonationForm/Blocks/DonationFormBlock/app/templates/index.tsx
@@ -14,6 +14,7 @@ import Form, {FormProps} from './layouts/Form';
 import AmountField from './fields/Amount';
 import classNames from 'classnames';
 import Gateways from './fields/Gateways';
+import Paragraph from './elements/Paragraph';
 
 export function NodeWrapper({
     type,
@@ -59,6 +60,7 @@ const defaultTemplate = {
         gateways: Gateways,
     },
     elements: {
+        paragraph: Paragraph,
         html: HtmlElement,
         donationSummary: DonationSummaryElement,
     },


### PR DESCRIPTION
## Description

This adds a paragraph element to the Form Builder! It allows folks to add simple text anywhere in any form. I looked into text formatting, and even added support for the core bold, italics, and link formats, but we apparently will need to [register format types](https://webomnizz.com/gutenberg-editor-add-button-to-the-toolbar/) in our app to get those to work properly. The [core types](https://github.com/WordPress/gutenberg/blob/0638a8c52199381080abb809fd5ccd137db5bb45/packages/format-library/src/bold/index.js) look easily available. I think it's fine if we add those in a subsequent PR.

## Affects

Didn't really change too much, just added the element.

## Testing Instructions

Use the block (or a few) in the Form Builder and check it out!

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

