### PR TITLE
Refactor: donation form now only loads scripts and styles that it needs

### DIFF
--- a/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
+++ b/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
@@ -40,10 +40,15 @@ class DonationFormViewController {
     private function head()
     {
         global $wp_scripts, $wp_styles;
-        wp_head();
+        add_action('wp_print_scripts', function () {
+            wp_dequeue_script('give');
+            wp_dequeue_script('give_recurring_script');
+        });
 
-        $wp_styles->dequeue(array_column($wp_styles->registered,'handle'));
-        $wp_scripts->dequeue(array_column($wp_scripts->registered,'handle'));
+        $wp_styles->dequeue(array_column($wp_styles->registered, 'handle'));
+        $wp_scripts->dequeue(array_column($wp_scripts->registered, 'handle'));
+
+        wp_head();
     }
 
      /**

--- a/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
+++ b/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
@@ -10,15 +10,31 @@ use Give\NextGen\Framework\FormTemplates\Registrars\FormTemplateRegistrar;
 
 class DonationFormViewController {
     /**
+     * This renders the donation form view.
+     *
+     * This is the order of loading:
+     * 1. Enqueue global styles from WP.
+     *  - This ensures template compatability with global WP css variables as needed. Loads before our templates, so they can use things like global font-family, etc.
+     * 2. Enqueue our donation form specific scripts & styles.
+     *  - We will let WP handle the actual printing depending on how they were enqueued.
+     * 3. Call the specific WP functions wp_print_styles() and wp_print_head_scripts()
+     *  - This will only print the styles and scripts that are enqueued within our route - so we don't have to dequeue a bunch of stuff.
+     * 4. Manually echo our window data and root div for our React app to consume
+     * 5. Finally, call the specific WP function wp_print_footer_scripts()
+     *  - This will only print the footer scripts that are enqueued within our route.
+     *
+     *
      * @unreleased
      */
     public function show(DonationFormViewRouteData $data): string
     {
         $viewModel = new DonationFormViewModel($data->formId);
+        wp_enqueue_global_styles();
+        $this->enqueueFormScripts($data->formId, $data->formTemplateId);
 
         ob_start();
-        $this->head();
-        $this->enqueueScripts($data->formId, $data->formTemplateId);
+        wp_print_styles();
+        wp_print_head_scripts();
         ?>
 
         <script>window.giveNextGenExports = <?= wp_json_encode($viewModel->exports()) ?>;</script>
@@ -32,25 +48,6 @@ class DonationFormViewController {
         exit();
     }
 
-    /**
-     * @unreleased
-     *
-     * @return void
-     */
-    private function head()
-    {
-        global $wp_scripts, $wp_styles;
-        add_action('wp_print_scripts', function () {
-            wp_dequeue_script('give');
-            wp_dequeue_script('give_recurring_script');
-        });
-
-        $wp_styles->dequeue(array_column($wp_styles->registered, 'handle'));
-        $wp_scripts->dequeue(array_column($wp_scripts->registered, 'handle'));
-
-        wp_head();
-    }
-
      /**
      * Loads scripts in order: [Registrars, Template, Gateways, Block]
      *
@@ -58,14 +55,14 @@ class DonationFormViewController {
      *
      * @return void
      */
-    private function enqueueScripts(int $formId, string $formTemplateId)
+    private function enqueueFormScripts(int $formId, string $formTemplateId)
     {
         /** @var DonationFormRepository $donationFormRepository */
         $donationFormRepository = give(DonationFormRepository::class);
 
         // load registrars
         (new EnqueueScript(
-            'give-donation-form-registrars-js',
+            'givewp-donation-form-registrars-js',
             'build/donationFormRegistrars.js',
             GIVE_NEXT_GEN_DIR,
             GIVE_NEXT_GEN_URL,
@@ -89,7 +86,7 @@ class DonationFormViewController {
                     'givewp-form-template-' . $template->getId(),
                     $template->js(),
                     array_merge(
-                        ['give-donation-form-registrars-js'],
+                        ['givewp-donation-form-registrars-js'],
                         $template->dependencies()
                     ),
                     false,
@@ -104,7 +101,7 @@ class DonationFormViewController {
                 /** @var EnqueueScript $script */
                 $script = $gateway->enqueueScript();
 
-                $script->dependencies(['give-donation-form-registrars-js'])
+                $script->dependencies(['givewp-donation-form-registrars-js'])
                     ->loadInFooter()
                     ->enqueue();
             }
@@ -112,12 +109,12 @@ class DonationFormViewController {
 
         // load block - since this is using render_callback viewScript in blocks.json will not work.
         (new EnqueueScript(
-            'give-next-gen-donation-form-block-js',
+            'givewp-next-gen-donation-form-block-js',
             'build/donationFormBlockApp.js',
             GIVE_NEXT_GEN_DIR,
             GIVE_NEXT_GEN_URL,
             'give'
-        ))->dependencies(['give-donation-form-registrars-js'])->loadInFooter()->enqueue();
+        ))->dependencies(['givewp-donation-form-registrars-js'])->loadInFooter()->enqueue();
 
         /**
          * Load iframeResizer.contentWindow.min.js inside iframe


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

While working on the design preview in the form builder, I discovered a script conflict being loaded from give core.  The real problem is that core scripts _were_ being loaded in the iframe (along with all kinds of other scripts from add-ons). The NextGen donation form has no business loading any other scripts than the ones it enqueues through our framework.  This PR rearranges our script loading process within the donation form to make the order and loading of scripts predictable and specific to our form.

The process was actually a lot simpler than I originally thought.  Instead of calling `wp_head()` and having to dequeue a bunch of stuff we can break out the printing into specific parts...

**This is the order of loading:**
 1. Enqueue global styles from WP using `wp_enqueue_global_styles()`.
    - This ensures template compatibility with global WP css variables as needed. Loads before our templates, so they can use things like global font-family, etc.  Also supports theme.js for FSE.
  2. Enqueue our donation form specific scripts & styles.
    - We will let WP handle the actual printing depending on how they were enqueued.
  3. Call the specific WP functions `wp_print_styles()` and `wp_print_head_scripts()`
    - This will only print the styles and scripts that are enqueued within our route - so we don't have to dequeue a bunch of stuff.
  4. Manually echo our window data and root div for our React app to consume
  5. Finally, call the specific WP function `wp_print_footer_scripts()`
    - This will only print the footer scripts that are enqueued within our route.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This affects the donation form but in a good way.  The form only loads the scripts it needs now. No more unused external scripts.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="464" alt="Screen Shot 2022-10-28 at 11 55 32 AM" src="https://user-images.githubusercontent.com/10138447/198681337-5edcbb8d-fde8-4eed-8e2f-1843c2463e45.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Just make sure a next gen form look and works the same.  There should be nothing unusual about it.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

