### PR TITLE
Refactor: form builder settings are now setup as a store with reducer

### DIFF
--- a/packages/form-builder/src/App.js
+++ b/packages/form-builder/src/App.js
@@ -1,83 +1,39 @@
-import React, {useState} from 'react';
+import React from 'react';
 
 import {ShortcutProvider} from '@wordpress/keyboard-shortcuts';
-import {BlockEditorProvider, BlockInspector} from '@wordpress/block-editor';
-import {Popover, SlotFillProvider} from '@wordpress/components';
-import {InterfaceSkeleton} from "@wordpress/interface";
-
-import HeaderContainer from './containers/HeaderContainer';
-import {SecondarySidebar, Sidebar} from './components';
-import {defaultFormSettings, FormSettingsProvider} from './settings/context';
+import BlockEditorContainer from './containers/BlockEditorContainer.tsx';
+import {FormSettingsProvider} from './stores/form-settings/index.tsx';
 import {Storage} from './common';
-
-import {useToggleState} from "./hooks";
 
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
 
 import './App.scss';
 
-import defaultBlocks from './blocks.json'
-import {FormBlocks, DesignPreview} from "./components/canvas";
+import defaultBlocks from './blocks.json';
+
+const {blocks: initialBlocks, settings: initialFormSettings} = Storage.load();
+
+const initialState = {
+    blocks: initialBlocks || defaultBlocks,
+    formTitle: 'My Default Donation Form Title',
+    enableDonationGoal: false,
+    enableAutoClose: false,
+    registration: 'none',
+    goalFormat: 'amount-raised',
+    ...initialFormSettings,
+};
+
+if (initialBlocks instanceof Error) {
+    alert('Unable to load initial blocks.');
+    console.error(initialBlocks);
+}
 
 function App() {
-
-    const {
-        state: showSidebar,
-        toggle: toggleShowSidebar,
-    } = useToggleState(true);
-
-    const [selectedSecondarySidebar, setSelectedSecondarySidebar] = useState('');
-    const toggleSelectedSecondarySidebar = (name) => setSelectedSecondarySidebar(name !== selectedSecondarySidebar ? name : false);
-
-    const {blocks: initialBlocks, settings: initialFormSettings} = Storage.load();
-    if (initialBlocks instanceof Error) {
-        alert('Unable to load initial blocks.');
-        console.error(initialBlocks);
-    }
-
-    const [formSettings, setFormSettings] = useState({
-        ...defaultFormSettings,
-        ...initialFormSettings,
-    });
-
-    const [blocks, updateBlocks] = useState(initialBlocks || defaultBlocks);
-
-    const saveCallback = () => {
-        return Storage.save({blocks, formSettings})
-                      .catch(error => alert(error.message));
-    };
-
-    const [selectedTab, setSelectedTab] = useState('form');
-
     return (
-        <FormSettingsProvider formSettings={formSettings} setFormSettings={setFormSettings}>
+        <FormSettingsProvider initialState={initialState}>
             <ShortcutProvider>
-                <BlockEditorProvider
-                    value={blocks}
-                    onInput={(blocks) => updateBlocks(blocks)}
-                    onChange={(blocks) => updateBlocks(blocks)}
-                >
-                    <SlotFillProvider>
-                        <Sidebar.InspectorFill>
-                            <BlockInspector />
-                        </Sidebar.InspectorFill>
-                        <InterfaceSkeleton
-                            header={<HeaderContainer
-                                saveCallback={saveCallback}
-                                selectedSecondarySidebar={selectedSecondarySidebar}
-                                toggleSelectedSecondarySidebar={toggleSelectedSecondarySidebar}
-                                showSidebar={showSidebar}
-                                toggleShowSidebar={toggleShowSidebar}
-                            />}
-                            content={'design' === selectedTab ? <DesignPreview blocks={blocks} /> : <FormBlocks />}
-                            sidebar={!!showSidebar && <Sidebar selectedTab={selectedTab} setSelectedTab={setSelectedTab} />}
-                            secondarySidebar={!!selectedSecondarySidebar &&
-                                <SecondarySidebar selected={selectedSecondarySidebar} />}
-                        />
-                        <Popover.Slot />
-                    </SlotFillProvider>
-                </BlockEditorProvider>
+                <BlockEditorContainer />
             </ShortcutProvider>
         </FormSettingsProvider>
     );

--- a/packages/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/packages/form-builder/src/containers/BlockEditorContainer.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import {useState} from 'react';
+import {BlockEditorProvider, BlockInspector} from '@wordpress/block-editor';
+import {Popover, SlotFillProvider} from '@wordpress/components';
+import {InterfaceSkeleton} from '@wordpress/interface';
+import useToggleState from '../hooks/useToggleState';
+
+import HeaderContainer from './HeaderContainer';
+
+import {SecondarySidebar, Sidebar} from '../components';
+
+import '@wordpress/components/build-style/style.css';
+import '@wordpress/block-editor/build-style/style.css';
+
+import '../App.scss';
+import {setFormBlocks, useFormSettings, useFormSettingsDispatch} from '../stores/form-settings/index.tsx';
+import {DesignPreview, FormBlocks} from '../components/canvas';
+
+export default function BlockEditorContainer() {
+    const {blocks} = useFormSettings();
+    const dispatch = useFormSettingsDispatch();
+    const dispatchFormBlocks = (blocks) => dispatch(setFormBlocks(blocks));
+
+    const {state: showSidebar, toggle: toggleShowSidebar} = useToggleState(true);
+    const [selectedSecondarySidebar, setSelectedSecondarySidebar] = useState('');
+    const [selectedTab, setSelectedTab] = useState('form');
+
+    return (
+        <BlockEditorProvider value={blocks} onInput={dispatchFormBlocks} onChange={dispatchFormBlocks}>
+            <SlotFillProvider>
+                <Sidebar.InspectorFill>
+                    <BlockInspector />
+                </Sidebar.InspectorFill>
+                <InterfaceSkeleton
+                    header={
+                        <HeaderContainer
+                            selectedSecondarySidebar={selectedSecondarySidebar}
+                            toggleSelectedSecondarySidebar={(name) =>
+                                setSelectedSecondarySidebar(name !== selectedSecondarySidebar ? name : false)
+                            }
+                            showSidebar={showSidebar}
+                            toggleShowSidebar={toggleShowSidebar}
+                        />
+                    }
+                    content={'design' === selectedTab ? <DesignPreview blocks={blocks} /> : <FormBlocks />}
+                    sidebar={!!showSidebar && <Sidebar selectedTab={selectedTab} setSelectedTab={setSelectedTab} />}
+                    secondarySidebar={
+                        !!selectedSecondarySidebar && <SecondarySidebar selected={selectedSecondarySidebar} />
+                    }
+                />
+                <Popover.Slot />
+            </SlotFillProvider>
+        </BlockEditorProvider>
+    );
+}

--- a/packages/form-builder/src/containers/HeaderContainer.jsx
+++ b/packages/form-builder/src/containers/HeaderContainer.jsx
@@ -1,52 +1,62 @@
-import React, {useState} from "react";
-import {AddIcon, GiveIcon, ListIcon, SettingsIcon} from "../components/icons";
-import {useFormSettings} from "../settings/context";
-import {RichText} from "@wordpress/block-editor";
-import {Button} from "@wordpress/components";
-import {__} from "@wordpress/i18n";
+import React, {useState} from 'react';
+import {AddIcon, GiveIcon, ListIcon, SettingsIcon} from '../components/icons';
+import {setFormSettings, useFormSettings, useFormSettingsDispatch} from '../stores/form-settings/index.tsx';
+import {RichText} from '@wordpress/block-editor';
+import {Button} from '@wordpress/components';
+import {__} from '@wordpress/i18n';
 import {Header} from '../components';
+import {Storage} from '../common';
 
 const HeaderContainer = ({
-                             saveCallback,
-                             selectedSecondarySidebar,
-                             toggleSelectedSecondarySidebar,
-                             showSidebar,
-                             toggleShowSidebar,
-                         }) => {
-
-    const [{formTitle}, updateFormSetting] = useFormSettings();
+    selectedSecondarySidebar,
+    toggleSelectedSecondarySidebar,
+    showSidebar,
+    toggleShowSidebar,
+}) => {
+    const formSettings = useFormSettings();
+    const {formTitle, blocks} = formSettings;
+    const dispatch = useFormSettingsDispatch();
 
     const [isSaving, setSaving] = useState(false);
 
     const onSave = () => {
         setSaving(true);
-        saveCallback().finally(() => {
-            setSaving(false);
-        });
+        Storage.save({blocks, formSettings})
+            .catch((error) => alert(error.message))
+            .finally(() => {
+                setSaving(false);
+            });
     };
 
     return (
         <Header
             contentLeft={
                 <>
-                    <div style={{
-                        height: '60px',
-                        width: '60px',
-                        backgroundColor: '#FFF',
-                        display: 'flex',
-                        alignItems: 'center',
-                    }}>
+                    <div
+                        style={{
+                            height: '60px',
+                            width: '60px',
+                            backgroundColor: '#FFF',
+                            display: 'flex',
+                            alignItems: 'center',
+                        }}
+                    >
                         <div>
                             <a href={'edit.php?post_type=give_forms&page=give-forms'} title={'Return to GiveWP'}>
                                 <GiveIcon />
                             </a>
                         </div>
                     </div>
-                    <Button onClick={() => toggleSelectedSecondarySidebar('add')}
-                            isPressed={'add' === selectedSecondarySidebar} icon={<AddIcon />}
-                            variant={'primary'} />
-                    <Button onClick={() => toggleSelectedSecondarySidebar('list')}
-                            isPressed={'list' === selectedSecondarySidebar} icon={<ListIcon />}
+                    <Button
+                        onClick={() => toggleSelectedSecondarySidebar('add')}
+                        isPressed={'add' === selectedSecondarySidebar}
+                        icon={<AddIcon />}
+                        variant={'primary'}
+                    />
+                    <Button
+                        onClick={() => toggleSelectedSecondarySidebar('list')}
+                        isPressed={'list' === selectedSecondarySidebar}
+                        icon={<ListIcon />}
                     />
                 </>
             }
@@ -54,7 +64,7 @@ const HeaderContainer = ({
                 <RichText
                     tagName="div"
                     value={formTitle}
-                    onChange={(value) => updateFormSetting({formTitle: value})}
+                    onChange={(value) => dispatch(setFormSettings({formTitle: value}))}
                     style={{fontSize: '16px'}}
                 />
             }

--- a/packages/form-builder/src/settings/donation-goal/index.js
+++ b/packages/form-builder/src/settings/donation-goal/index.js
@@ -1,16 +1,16 @@
-import {useFormSettings} from "../context";
-import {__} from "@wordpress/i18n";
+import {setFormSettings, useFormSettings, useFormSettingsDispatch} from '../../stores/form-settings/index.tsx';
+import {__} from '@wordpress/i18n';
 import {
     __experimentalNumberControl as NumberControl,
     PanelBody,
     PanelRow,
     SelectControl,
     ToggleControl,
-} from "@wordpress/components";
+} from '@wordpress/components';
 
 const DonationGoalSettings = () => {
-
-    const [{enableDonationGoal, enableAutoClose, goalFormat, goalAmount}, updateSetting] = useFormSettings();
+    const {enableDonationGoal, enableAutoClose, goalFormat, goalAmount} = useFormSettings();
+    const dispatch = useFormSettingsDispatch();
 
     const goalFormatOptions = [
         {
@@ -39,7 +39,7 @@ const DonationGoalSettings = () => {
                     help={__('Do you want to set a donation goal for this form?', 'give')}
                     checked={enableDonationGoal}
                     onChange={() => {
-                        updateSetting({enableDonationGoal: !enableDonationGoal});
+                        dispatch(setFormSettings({enableDonationGoal: !enableDonationGoal}));
                     }}
                 />
             </PanelRow>
@@ -49,9 +49,12 @@ const DonationGoalSettings = () => {
                     <PanelRow>
                         <ToggleControl
                             label={__('Auto-Close Form', 'give')}
-                            help={__('Do you want to close the donation forms and stop accepting donations once this goal has been met?', 'give')}
+                            help={__(
+                                'Do you want to close the donation forms and stop accepting donations once this goal has been met?',
+                                'give'
+                            )}
                             checked={enableAutoClose}
-                            onChange={() => updateSetting({enableAutoClose: !enableAutoClose})}
+                            onChange={() => dispatch(setFormSettings({enableAutoClose: !enableAutoClose}))}
                         />
                     </PanelRow>
                     <PanelRow>
@@ -59,16 +62,19 @@ const DonationGoalSettings = () => {
                             label={__('Goal Amount', 'give')}
                             min={0}
                             value={goalAmount}
-                            onChange={(goalAmount) => updateSetting({goalAmount})}
+                            onChange={(goalAmount) => dispatch(setFormSettings({goalAmount}))}
                         />
                     </PanelRow>
                     <PanelRow>
                         <SelectControl
                             label={__('Goal Format', 'give')}
-                            help={__('Do you want to display the total amount raised based on your monetary goal or a percentage? For instance, "$500 of $1,000 raised" or "50% funded" or "1 of 5 donations". You can also display a donor-based goal, such as "100 of 1,000 donors have given".', 'give')}
+                            help={__(
+                                'Do you want to display the total amount raised based on your monetary goal or a percentage? For instance, "$500 of $1,000 raised" or "50% funded" or "1 of 5 donations". You can also display a donor-based goal, such as "100 of 1,000 donors have given".',
+                                'give'
+                            )}
                             selected={goalFormat}
                             options={goalFormatOptions}
-                            onChange={(goalFormat) => updateSetting({goalFormat})}
+                            onChange={(goalFormat) => dispatch(setFormSettings({goalFormat}))}
                         />
                     </PanelRow>
                 </>

--- a/packages/form-builder/src/settings/form-fields/index.js
+++ b/packages/form-builder/src/settings/form-fields/index.js
@@ -1,11 +1,10 @@
-import {useFormSettings} from "../context";
-import {__} from "@wordpress/i18n";
-import {PanelBody, PanelRow, SelectControl, ToggleControl} from "@wordpress/components";
+import {setFormSettings, useFormSettings, useFormSettingsDispatch} from '../../stores/form-settings/index.tsx';
+import {__} from '@wordpress/i18n';
+import {PanelBody, PanelRow, SelectControl, ToggleControl} from '@wordpress/components';
 
 const FormFieldSettings = () => {
-
-    const [{registration, anonymousDonations, guestDonations}, updateSetting] = useFormSettings();
-
+    const {registration, anonymousDonations, guestDonations} = useFormSettings();
+    const dispatch = useFormSettingsDispatch();
 
     const registrationOptions = [
         {
@@ -32,24 +31,27 @@ const FormFieldSettings = () => {
                 <SelectControl
                     labelPosition={'left'}
                     label={__('Registration', 'give')}
-                    help={__('Display the registration and/or login forms in the payment section for non-logged-in users.', 'give')}
+                    help={__(
+                        'Display the registration and/or login forms in the payment section for non-logged-in users.',
+                        'give'
+                    )}
                     value={registration}
                     options={registrationOptions}
-                    onChange={(registration) => updateSetting({registration: registration})}
+                    onChange={(registration) => dispatch(setFormSettings({registration}))}
                 />
             </PanelRow>
             <PanelRow>
                 <ToggleControl
                     label={__('Anonymous Donations', 'give')}
                     checked={anonymousDonations}
-                    onChange={() => updateSetting({anonymousDonations: !anonymousDonations})}
+                    onChange={() => dispatch(setFormSettings({anonymousDonations: !anonymousDonations}))}
                 />
             </PanelRow>
             <PanelRow>
                 <ToggleControl
                     label={__('Allow Guest Donations', 'give')}
                     checked={guestDonations}
-                    onChange={() => updateSetting({guestDonations: !guestDonations})}
+                    onChange={() => dispatch(setFormSettings({guestDonations: !guestDonations}))}
                 />
             </PanelRow>
         </PanelBody>

--- a/packages/form-builder/src/settings/form-title/index.js
+++ b/packages/form-builder/src/settings/form-title/index.js
@@ -1,10 +1,10 @@
-import {PanelBody, PanelRow, TextControl} from "@wordpress/components";
-import {__} from "@wordpress/i18n";
-import {useFormSettings} from "../context";
+import {PanelBody, PanelRow, TextControl} from '@wordpress/components';
+import {__} from '@wordpress/i18n';
+import {setFormSettings, useFormSettings, useFormSettingsDispatch} from '../../stores/form-settings/index.tsx';
 
 const FormTitleSettings = () => {
-
-    const [{formTitle}, updateFormSetting] = useFormSettings();
+    const {formTitle} = useFormSettings();
+    const dispatch = useFormSettingsDispatch();
 
     return (
         <PanelBody>
@@ -12,7 +12,7 @@ const FormTitleSettings = () => {
                 <TextControl
                     label={__('Form Title')}
                     value={formTitle}
-                    onChange={(formTitle) => updateFormSetting({formTitle})}
+                    onChange={(formTitle) => dispatch(setFormSettings({formTitle}))}
                 />
             </PanelRow>
         </PanelBody>

--- a/packages/form-builder/src/settings/offline-donation/index.js
+++ b/packages/form-builder/src/settings/offline-donation/index.js
@@ -1,11 +1,11 @@
-import {useFormSettings} from "../context";
-import {PanelBody, PanelRow, ToggleControl} from "@wordpress/components";
-import {__} from "@wordpress/i18n";
+import {setFormSettings, useFormSettings, useFormSettingsDispatch} from '../../stores/form-settings/index.tsx';
+import {PanelBody, PanelRow, ToggleControl} from '@wordpress/components';
+import {__} from '@wordpress/i18n';
 import DonationInstructions from './donation-instructions';
 
 const OfflineDonationsSettings = () => {
-
-    const [{enableOfflineDonations, enableBillingFields}, updateSetting] = useFormSettings();
+    const {enableOfflineDonations, enableBillingFields} = useFormSettings();
+    const dispatch = useFormSettingsDispatch();
 
     return (
         <PanelBody title={__('Offline Donations', 'give')} initialOpen={false}>
@@ -14,7 +14,7 @@ const OfflineDonationsSettings = () => {
                     label={__('Enable Offline Donations', 'give')}
                     help={__('Do you want to customize the donation instructions for this form?', 'give')}
                     checked={enableOfflineDonations}
-                    onChange={() => updateSetting({enableOfflineDonations: !enableOfflineDonations})}
+                    onChange={() => dispatch(setFormSettings({enableOfflineDonations: !enableOfflineDonations}))}
                 />
             </PanelRow>
             {enableOfflineDonations && (
@@ -22,9 +22,12 @@ const OfflineDonationsSettings = () => {
                     <PanelRow>
                         <ToggleControl
                             label={__('Enable Billing Fields', 'give')}
-                            help={__('DThis option will enable the billing details section for this form\'s offline donation payment gateway. The fieldset will appear above the offline donation instructions.', 'give')}
+                            help={__(
+                                "DThis option will enable the billing details section for this form's offline donation payment gateway. The fieldset will appear above the offline donation instructions.",
+                                'give'
+                            )}
                             checked={enableBillingFields}
-                            onChange={() => updateSetting({enableBillingFields: !enableBillingFields})}
+                            onChange={() => dispatch(setFormSettings({enableBillingFields: !enableBillingFields}))}
                         />
                     </PanelRow>
                     <PanelRow>

--- a/packages/form-builder/src/stores/form-settings/index.tsx
+++ b/packages/form-builder/src/stores/form-settings/index.tsx
@@ -1,0 +1,68 @@
+import {createContext, ReactNode, useContext, useReducer} from 'react';
+import formSettingsReducer, {setFormBlocks, setFormSettings} from './reducer.ts';
+
+const StoreContext = createContext(null);
+StoreContext.displayName = 'FormSettingsStoreContext';
+
+const StoreContextDispatch = createContext(null);
+StoreContextDispatch.displayName = 'FormSettingsStoreContextDispatch';
+
+/**
+ * TODO: format settings object by category
+ *
+ * @unreleased
+ */
+type FormSettings = {
+    blocks: object;
+    formTitle: string;
+    enableDonationGoal: boolean;
+    enableAutoClose: boolean;
+    registration: string;
+    goalFormat: string;
+};
+
+/**
+ * This is our Form's store for its settings.
+ * It uses the React hook useReducer to store and persist state.
+ * In order to update the state a "dispatch" method will be provided from the reducer.
+ * This provides a lot of flexibility and performance benefits.
+ *
+ * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+ *
+ * @unreleased
+ */
+const FormSettingsProvider = ({initialState, children}: {initialState: FormSettings,children: ReactNode}) => {
+    const [state, dispatch] = useReducer(formSettingsReducer, initialState);
+
+    return (
+        <StoreContext.Provider value={state}>
+            <StoreContextDispatch.Provider value={dispatch}>{children}</StoreContextDispatch.Provider>
+        </StoreContext.Provider>
+    );
+};
+
+/**
+ * This is a convenient way of retrieving all the settings from the store as readOnly
+ *
+ * @unreleased
+ *
+ * @example
+ *  const {formTitle} = useFormSettings();
+ */
+const useFormSettings = () => useContext(StoreContext);
+
+/**
+ * This is a convenient way of retrieving the "dispatch" function from our provider
+ *
+ * @unreleased
+ *
+ * @example
+ * // retrieve the "dispatch" function
+ * const dispatch = useCampaignSettingsDispatch();
+ *
+ * // use the "dispatch" function
+ * dispatch(setFormSettings({formTitle: 'new title'}));
+ */
+const useFormSettingsDispatch = () => useContext(StoreContextDispatch);
+
+export {FormSettingsProvider, useFormSettings, useFormSettingsDispatch, setFormSettings, setFormBlocks};

--- a/packages/form-builder/src/stores/form-settings/reducer.ts
+++ b/packages/form-builder/src/stores/form-settings/reducer.ts
@@ -1,0 +1,45 @@
+const UPDATE_SETTINGS = 'update_settings';
+const UPDATE_BLOCKS = 'update_blocks';
+
+/**
+ * This reducer is used within the FormSettingsProvider for state management
+ *
+ * @unreleased
+ */
+export default function reducer(state, action) {
+    switch (action.type) {
+        case UPDATE_SETTINGS:
+            return {
+                ...state,
+                ...action.settings,
+            };
+        case UPDATE_BLOCKS:
+            return {
+                ...state,
+                blocks: action.blocks
+            };
+
+        default:
+            return state;
+    }
+}
+
+/**
+ * @unreleased
+ */
+export function setFormSettings(settings) {
+    return {
+        type: UPDATE_SETTINGS,
+        settings,
+    };
+}
+
+/**
+ * @unreleased
+ */
+export function setFormBlocks(blocks) {
+    return {
+        type: UPDATE_BLOCKS,
+        blocks,
+    };
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #17

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

As the form builder application continues to grow, it's necessary to think through our data flow as it relates to all the new features we plan on implementing.  This PR replaces the existing state management approach with a reducer powered approach. This will give us a lot more flexibility in the future along with performance benefits.

**Provider**
- FormSettingsProvider

This is our Form's new store/provider.  It uses the React hook useReducer to store and persist state under the hood.  In order to update the state a "dispatch" method will be provided from the reducer.   This provides a lot of flexibility and performance benefits.

**Hooks**
- useFormSettings: convenient way of retrieving all the settings from the store as readOnly
- useFormSettingsDispatch: convenient way of retrieving the "dispatch" function from our provider


```
const FormTitleSettings = () => {
    const {formTitle} = useFormSettings();
    const dispatch = useFormSettingsDispatch();

    return (
        <PanelBody>
            <PanelRow>
                <TextControl
                    label={__('Form Title')}
                    value={formTitle}
                    onChange={(formTitle) => dispatch(setFormSettings({formTitle}))}
                />
            </PanelRow>
        </PanelBody>
    );
};
```

Notice we are dispatching `setFormSettings()` - this is just a declarative abstraction for something like this:
```
dispatch({type: 'update_settings', settings: {formTitle})
```

Creating these reducer dispatch functions make updating nested object much easier.  In the future I anticipate having breaking out the form settings into nested objects that describe themselves with matching functions.  Think design/template settings, goal settings, addon settings, etc.


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form builder application's front-end state management.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

There is no visual change.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Just make sure everything still works as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203272136087566