### PR TITLE
Design Preview can now switch templates

### DIFF
--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -135,7 +135,7 @@
  * Fixes an issue with inspector select controls covering selected option.
  */
 .components-select-control__input {
-    padding: 8px;
+    //padding: 8px;
     font-weight: normal;
 }
 

--- a/packages/form-builder/src/App.tsx
+++ b/packages/form-builder/src/App.tsx
@@ -12,7 +12,7 @@ import './App.scss';
 
 import defaultBlocks from './blocks.json';
 
-const {blocks: initialBlocks, settings: initialFormSettings} = Storage.load();
+const {blocks: initialBlocks, formSettings: initialFormSettings} = Storage.load();
 
 const initialState = {
     blocks: initialBlocks || defaultBlocks,
@@ -21,8 +21,14 @@ const initialState = {
     enableAutoClose: false,
     registration: 'none',
     goalFormat: 'amount-raised',
+    template: 'classic',
     ...initialFormSettings,
 };
+
+console.log(
+    initialFormSettings,
+    initialState
+)
 
 if (initialBlocks instanceof Error) {
     alert('Unable to load initial blocks.');

--- a/packages/form-builder/src/App.tsx
+++ b/packages/form-builder/src/App.tsx
@@ -25,11 +25,6 @@ const initialState = {
     ...initialFormSettings,
 };
 
-console.log(
-    initialFormSettings,
-    initialState
-)
-
 if (initialBlocks instanceof Error) {
     alert('Unable to load initial blocks.');
     console.error(initialBlocks);

--- a/packages/form-builder/src/common/storage/drivers/local.ts
+++ b/packages/form-builder/src/common/storage/drivers/local.ts
@@ -35,12 +35,13 @@ const localStorageDriver: StorageDriver = {
     /**
      * Generate form preview
      *
+     * @param template
      * @param blocks
      */
-    preview: (blocks: Block[]) => {
+    preview: (template: string, blocks: Block[]) => {
         return new Promise<string>((resolve) => {
             setTimeout(function () {
-                resolve(JSON.stringify(blocks));
+                resolve(template + JSON.stringify(blocks));
             }, 1000);
         });
     }

--- a/packages/form-builder/src/common/storage/interface.ts
+++ b/packages/form-builder/src/common/storage/interface.ts
@@ -4,5 +4,5 @@ import {Block} from "../../types/block";
 export interface StorageDriver {
     save({blocks, formSettings}: FormData): Promise<void>,
     load(): FormData,
-    preview(blocks: Block[]): Promise<string>,
+    preview(template: string, blocks: Block[]): Promise<string>,
 }

--- a/packages/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/packages/form-builder/src/components/canvas/DesignPreview.tsx
@@ -1,22 +1,21 @@
 import * as React from 'react';
 import {useEffect, useState} from 'react';
-import type {Block} from '../../types/block';
 
 import Storage from '../../common/storage/index.ts';
 
 import IframeResizer from 'iframe-resizer-react';
+import {useFormSettings} from "../../stores/form-settings/index.tsx";
 
-type PropTypes = {
-    blocks: Block[];
-};
-
-const DesignPreview = ({blocks}: PropTypes) => {
+const DesignPreview = () => {
+    const {blocks, template} = useFormSettings();
     const [sourceDocument, setSourceDocument] = useState('');
 
     useEffect(() => {
-        Storage.preview(blocks).then(setSourceDocument);
-        // stringify to prevent re-renders caused by object as dep
-    }, [JSON.stringify(blocks)]);
+        Storage.preview(template, blocks).then(setSourceDocument);
+    }, [
+        template,
+        JSON.stringify(blocks) // stringify to prevent re-renders caused by object as dep
+    ]);
 
     return !sourceDocument ? (
         'Loading...'

--- a/packages/form-builder/src/components/sidebar/primary.js
+++ b/packages/form-builder/src/components/sidebar/primary.js
@@ -3,11 +3,12 @@ import {__} from '@wordpress/i18n';
 
 import TabPanel from './tab-panel';
 
-import {DonationGoalSettings, FormTitleSettings, OfflineDonationsSettings} from '../../settings';
+import {DonationGoalSettings, FormTitleSettings, OfflineDonationsSettings, TemplateSettings} from '../../settings/index.ts';
 import FormFields from "../../settings/form-fields";
 import {PopoutSlot} from "./popout";
 import {useEffect} from "react";
 import useSelectedBlocks from "../../hooks/useSelectedBlocks";
+import {useFormSettings, useFormSettingsDispatch} from "../../stores/form-settings/index.tsx";
 
 const {Slot: InspectorSlot, Fill: InspectorFill} = createSlotFill(
     'StandAloneBlockEditorSidebarInspector',
@@ -41,11 +42,7 @@ const tabs = [
         name: 'design',
         title: __('Design'),
         className: 'tab-block',
-        content: () => (
-            <>
-                <span className={'block-editor-block-inspector__no-blocks'}>No template selected.</span>
-            </>
-        ),
+        content: () => <TemplateSettings />
     },
 ];
 

--- a/packages/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/packages/form-builder/src/containers/BlockEditorContainer.tsx
@@ -42,7 +42,7 @@ export default function BlockEditorContainer() {
                             toggleShowSidebar={toggleShowSidebar}
                         />
                     }
-                    content={'design' === selectedTab ? <DesignPreview blocks={blocks} /> : <FormBlocks />}
+                    content={'design' === selectedTab ? <DesignPreview /> : <FormBlocks />}
                     sidebar={!!showSidebar && <Sidebar selectedTab={selectedTab} setSelectedTab={setSelectedTab} />}
                     secondarySidebar={
                         !!selectedSecondarySidebar && <SecondarySidebar selected={selectedSecondarySidebar} />

--- a/packages/form-builder/src/settings/donation-goal/index.js
+++ b/packages/form-builder/src/settings/donation-goal/index.js
@@ -72,7 +72,7 @@ const DonationGoalSettings = () => {
                                 'Do you want to display the total amount raised based on your monetary goal or a percentage? For instance, "$500 of $1,000 raised" or "50% funded" or "1 of 5 donations". You can also display a donor-based goal, such as "100 of 1,000 donors have given".',
                                 'give'
                             )}
-                            selected={goalFormat}
+                            value={goalFormat}
                             options={goalFormatOptions}
                             onChange={(goalFormat) => dispatch(setFormSettings({goalFormat}))}
                         />

--- a/packages/form-builder/src/settings/index.ts
+++ b/packages/form-builder/src/settings/index.ts
@@ -2,10 +2,12 @@ import DonationGoalSettings from './donation-goal';
 import FormFieldSettings from './form-fields';
 import FormTitleSettings from './form-title';
 import OfflineDonationsSettings from './offline-donation';
+import TemplateSettings from './template/index.tsx'
 
 export {
     DonationGoalSettings,
     FormFieldSettings,
     FormTitleSettings,
     OfflineDonationsSettings,
+    TemplateSettings,
 };

--- a/packages/form-builder/src/settings/template/index.tsx
+++ b/packages/form-builder/src/settings/template/index.tsx
@@ -1,5 +1,4 @@
-import {PanelBody, PanelRow, SelectControl, TextControl} from '@wordpress/components';
-import {BlockCard} from '@wordpress/block-editor'
+import {PanelBody, PanelRow, SelectControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {setFormSettings, useFormSettings, useFormSettingsDispatch} from '../../stores/form-settings/index.tsx';
 
@@ -12,21 +11,13 @@ const TemplateSettings = () => {
         {value: 'classic', label: __('Classic', 'givewp')},
     ]
 
-    const selectedTemplate = templateOptions.filter((option) => option.value === template).pop()
-
     return (
         <PanelBody>
             <PanelRow>
-                { template
-                    ? <div>{selectedTemplate.label}</div> // @todo Update to match the design
-                    : <span className={'block-editor-block-inspector__no-blocks'}>{__('No template selected.', 'givewp')}</span>
-                }
-            </PanelRow>
-            <PanelRow>
                 <SelectControl
                     labelPosition={'left'}
-                    label={__('Form Title')}
-                    selected={template}
+                    label={__('Form template', 'givewp')}
+                    value={template}
                     onChange={(template) => dispatch(setFormSettings({template}))}
                     options={templateOptions}
                 />

--- a/packages/form-builder/src/settings/template/index.tsx
+++ b/packages/form-builder/src/settings/template/index.tsx
@@ -1,0 +1,38 @@
+import {PanelBody, PanelRow, SelectControl, TextControl} from '@wordpress/components';
+import {BlockCard} from '@wordpress/block-editor'
+import {__} from '@wordpress/i18n';
+import {setFormSettings, useFormSettings, useFormSettingsDispatch} from '../../stores/form-settings/index.tsx';
+
+const TemplateSettings = () => {
+    const {template} = useFormSettings();
+    const dispatch = useFormSettingsDispatch();
+
+    const templateOptions = [
+        {value: '', label: __('No Template', 'givewp')},
+        {value: 'classic', label: __('Classic', 'givewp')},
+    ]
+
+    const selectedTemplate = templateOptions.filter((option) => option.value === template).pop()
+
+    return (
+        <PanelBody>
+            <PanelRow>
+                { template
+                    ? <div>{selectedTemplate.label}</div> // @todo Update to match the design
+                    : <span className={'block-editor-block-inspector__no-blocks'}>{__('No template selected.', 'givewp')}</span>
+                }
+            </PanelRow>
+            <PanelRow>
+                <SelectControl
+                    labelPosition={'left'}
+                    label={__('Form Title')}
+                    selected={template}
+                    onChange={(template) => dispatch(setFormSettings({template}))}
+                    options={templateOptions}
+                />
+            </PanelRow>
+        </PanelBody>
+    );
+};
+
+export default TemplateSettings;

--- a/packages/form-builder/src/stores/form-settings/index.tsx
+++ b/packages/form-builder/src/stores/form-settings/index.tsx
@@ -18,6 +18,7 @@ export type FormSettings = {
     enableAutoClose: boolean;
     registration: string;
     goalFormat: string;
+    template: string;
 };
 
 /**

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -13,7 +13,7 @@ class FormBuilderViewModel
     {
         return [
             'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $donationFormId),
-            'previewURL' => site_url("?givewp-view=donation-form&form-id=$donationFormId&form-template-id=classic"),
+            'previewURL' => site_url("?givewp-view=donation-form&form-id=$donationFormId"),
             'nonce' => wp_create_nonce('wp_rest'),
             'blockData' => get_post($donationFormId)->post_content,
             'settings' => get_post_meta($donationFormId, 'formBuilderSettings', true),

--- a/src/FormBuilder/resources/js/storage.js
+++ b/src/FormBuilder/resources/js/storage.js
@@ -27,7 +27,7 @@ window.storage = {
             settings: JSON.parse( window.storageData.settings || "{}" ),
         };
     },
-    preview: ( blocks ) => {
+    preview: ( template, blocks ) => {
         return new Promise((resolve, reject) => {
             jQuery
                 .post({
@@ -36,6 +36,7 @@ window.storage = {
                         'X-WP-Nonce': window.storageData.nonce,
                     },
                     data: {
+                        'form-template-id': template,
                         'form-blocks': JSON.stringify(blocks),
                     },
                 })

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -30,7 +30,7 @@ class FormBuilderViewModelTest extends TestCase
             $viewModel->storageData($formId),
             [
                 'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $formId),
-                'previewURL' => site_url("?givewp-view=donation-form&form-id=$formId&form-template-id=classic"),
+                'previewURL' => site_url("?givewp-view=donation-form&form-id=$formId"),
                 'nonce' => wp_create_nonce('wp_rest'),
                 'blockData' => get_post($formId)->post_content,
                 'settings' => get_post_meta($formId, 'formBuilderSettings', true),


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new `template` form setting with a corresponding `<SelectControl />` which switches the template used in the `<DesignPreview />` canvas.

NOTE: There are some styling issues with the `<select />` element that need to be addressed.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/199791900-8c107fad-f8eb-484f-8767-36f9153e0f57.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

