### PR TITLE
Refactor: Design Preview update is now rendered in the background

### DIFF
--- a/packages/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/packages/form-builder/src/components/canvas/DesignPreview.tsx
@@ -9,9 +9,9 @@ import DesignPreviewLoading from "@givewp/form-builder/components/canvas/DesignP
 
 const DesignPreview = () => {
     const {blocks, settings: formSettings} = useFormState();
-    const [isLoading, setLoading] = useState(true);
-    const [sourceDocument, setSourceDocument] = useState(null);
-    const [previewHTML, setPreviewHTML] = useState(null);
+    const [isLoading, setLoading] = useState<boolean>(false);
+    const [sourceDocument, setSourceDocument] = useState<string>(null);
+    const [previewHTML, setPreviewHTML] = useState<string>(null);
 
     useEffect(() => {
         setLoading(true);

--- a/packages/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/packages/form-builder/src/components/canvas/DesignPreview.tsx
@@ -1,41 +1,53 @@
 import * as React from 'react';
 import {useEffect, useState} from 'react';
-import DesignPreviewLoading from './DesignPreviewLoading';
 
 import Storage from '@givewp/form-builder/common/storage';
 
 import IframeResizer from 'iframe-resizer-react';
 import {useFormState} from '../../stores/form-state';
+import DesignPreviewLoading from "@givewp/form-builder/components/canvas/DesignPreviewLoading";
 
 const DesignPreview = () => {
     const {blocks, settings: formSettings} = useFormState();
-    const [sourceDocument, setSourceDocument] = useState('');
-    const [isLoading, setIsLoading] = useState<boolean>();
+    const [isLoading, setLoading] = useState(true);
+    const [sourceDocument, setSourceDocument] = useState(null);
+    const [previousPreviewHTML, setPreviousPreviewHTML] = useState(null);
 
     useEffect(() => {
-        setIsLoading(true);
+        setLoading(true);
         Storage.preview({blocks, formSettings}).then((document) => {
             setSourceDocument(document);
-            setIsLoading(false);
         });
     }, [
         JSON.stringify(formSettings),
         JSON.stringify(blocks), // stringify to prevent re-renders caused by object as dep
     ]);
 
-    return isLoading ? (
-        <DesignPreviewLoading />
-    ) : (
-        <IframeResizer
-            srcDoc={sourceDocument}
-            checkOrigin={false} /** The srcDoc property is not a URL and requires that the origin check be disabled. */
-            style={{
-                width: '1px',
-                minWidth: '100%',
-                border: '0',
-            }}
-        />
-    );
+    const iframeStyles = {
+        width: '1px',
+        minWidth: '100%',
+        border: '0',
+    }
+
+    return (
+        <>
+            {isLoading && <DesignPreviewLoading />}
+            <IframeResizer
+                onLoad={(event) => {
+                    const target = event.target as HTMLIFrameElement;
+                    setPreviousPreviewHTML(target.contentWindow.document.documentElement.innerHTML)
+                    setLoading(false)
+                }}
+                srcDoc={sourceDocument}
+                style={{display: 'none'}}
+            />
+            <IframeResizer
+                srcDoc={previousPreviewHTML}
+                checkOrigin={false} /** The srcDoc property is not a URL and requires that the origin check be disabled. */
+                style={iframeStyles}
+            />
+        </>
+    )
 };
 
 export default DesignPreview;

--- a/packages/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/packages/form-builder/src/components/canvas/DesignPreview.tsx
@@ -11,7 +11,7 @@ const DesignPreview = () => {
     const {blocks, settings: formSettings} = useFormState();
     const [isLoading, setLoading] = useState(true);
     const [sourceDocument, setSourceDocument] = useState(null);
-    const [previousPreviewHTML, setPreviousPreviewHTML] = useState(null);
+    const [previewHTML, setPreviewHTML] = useState(null);
 
     useEffect(() => {
         setLoading(true);
@@ -23,28 +23,28 @@ const DesignPreview = () => {
         JSON.stringify(blocks), // stringify to prevent re-renders caused by object as dep
     ]);
 
-    const iframeStyles = {
-        width: '1px',
-        minWidth: '100%',
-        border: '0',
-    }
-
     return (
         <>
             {isLoading && <DesignPreviewLoading />}
             <IframeResizer
+                srcDoc={previewHTML}
+                checkOrigin={false} /** The srcDoc property is not a URL and requires that the origin check be disabled. */
+                style={{
+                    width: '1px',
+                    minWidth: '100%',
+                    border: '0',
+                }}
+            />
+
+            {/* @note This iFrame is used to load and render the design preview document in the background. */}
+            <iframe
                 onLoad={(event) => {
                     const target = event.target as HTMLIFrameElement;
-                    setPreviousPreviewHTML(target.contentWindow.document.documentElement.innerHTML)
+                    setPreviewHTML(target.contentWindow.document.documentElement.innerHTML)
                     setLoading(false)
                 }}
                 srcDoc={sourceDocument}
                 style={{display: 'none'}}
-            />
-            <IframeResizer
-                srcDoc={previousPreviewHTML}
-                checkOrigin={false} /** The srcDoc property is not a URL and requires that the origin check be disabled. */
-                style={iframeStyles}
             />
         </>
     )

--- a/packages/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
+++ b/packages/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
@@ -1,11 +1,13 @@
 .givewp__component {
     &--DesignPreviewLoading {
+
+        position: absolute;
+        margin-top: -48px;
+
         width: 100%;
-        height: 100vh;
         display: flex;
         align-items: flex-start;
         justify-content: center;
-        padding-top: 1rem;
 
         svg {
             width: 32px;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR improves the Design Preview by rendering the updated preview in the background and only updating the preview after the document is fully rendered.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![Peek 2022-11-14 14-23](https://user-images.githubusercontent.com/10858303/201748998-26431617-226f-43b6-a8e3-78d36d340f0b.gif)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

