### PR TITLE
Feature: add separate route for form preview and introduce `FormSettings` property

### DIFF
--- a/src/FormBuilder/Controllers/FormBuilderResourceController.php
+++ b/src/FormBuilder/Controllers/FormBuilderResourceController.php
@@ -5,6 +5,7 @@ namespace Give\FormBuilder\Controllers;
 use Give\Framework\Exceptions\Primitives\Exception;
 use Give\Framework\FieldsAPI\Form;
 use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\Framework\Blocks\BlockCollection;
 use WP_Error;
 use WP_HTTP_Response;
@@ -38,7 +39,7 @@ class FormBuilderResourceController
 
         return rest_ensure_response([
             'blocks' => $form->blocks->toJson(),
-            'settings' => json_encode($form->settings)
+            'settings' => $form->settings->toJson()
         ]);
     }
 
@@ -65,9 +66,10 @@ class FormBuilderResourceController
 
         $blocks = BlockCollection::fromJson($rawBlocks);
 
-        $updatedSettings = json_decode($formBuilderSettings, true);
-        $form->settings = array_merge($form->settings ?? [], $updatedSettings);
-        $form->title = $updatedSettings['formTitle'];
+        $updatedSettings = FormSettings::fromJson($formBuilderSettings);
+
+        $form->settings = $updatedSettings;
+        $form->title = $updatedSettings->formTitle;
         $form->blocks = $blocks;
 
         if ($requiredFieldsError = $this->validateRequiredFields($form->schema())) {
@@ -77,7 +79,7 @@ class FormBuilderResourceController
         $form->save();
 
         return rest_ensure_response([
-            'settings' => json_encode($form->settings),
+            'settings' => $form->settings->toJson(),
             'form' => $form->id,
         ]);
     }

--- a/src/FormBuilder/Routes/CreateFormRoute.php
+++ b/src/FormBuilder/Routes/CreateFormRoute.php
@@ -4,8 +4,9 @@ namespace Give\FormBuilder\Routes;
 
 use Exception;
 use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\ValueObjects\DonationFormStatus;
-use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
 use Give\NextGen\Framework\Blocks\BlockCollection;
 
 /**
@@ -33,12 +34,21 @@ class CreateFormRoute
                 $form = DonationForm::create([
                     'title' => __('GiveWP Donation Form', 'give'),
                     'status' => DonationFormStatus::PUBLISHED(),
-                    'settings' => [
+                    'settings' => FormSettings::fromArray([
                         'enableDonationGoal' => false,
+                        'goalAmount' => 1000,
                         'enableAutoClose' => false,
                         'registration' => 'none',
-                        'goalType' => GoalTypeOptions::AMOUNT,
-                    ],
+                        'goalType' => GoalType::AMOUNT(),
+                        'designId' => 'classic',
+                        'showHeading' => true,
+                        'showDescription' => true,
+                        'heading' => __('Support Our Cause', 'give'),
+                        'description' => __(
+                            'Help our organization by donating today! All donations go directly to making a difference for our cause.',
+                            'give'
+                        )
+                    ]),
                     'blocks' => BlockCollection::fromJson($blocksJson)
                 ]);
 

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -23,7 +23,7 @@ class FormBuilderViewModel
             'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($donationFormId),
             'nonce' => wp_create_nonce('wp_rest'),
             'blockData' => $donationForm->blocks->toJson(),
-            'settings' => json_encode($donationForm->settings),
+            'settings' => $donationForm->settings->toJson(),
             'currency' => give_get_currency(),
             'formDesigns' => array_map(static function ($designClass) {
                 /** @var FormDesign $design */

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -3,6 +3,8 @@
 namespace Give\FormBuilder\ViewModels;
 
 use Give\FormBuilder\ValueObjects\FormBuilderRestRouteConfig;
+use Give\NextGen\DonationForm\Actions\GenerateDonationFormPreviewRouteUrl;
+use Give\NextGen\DonationForm\Models\DonationForm;
 use Give\NextGen\Framework\FormDesigns\FormDesign;
 use Give\NextGen\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 
@@ -13,12 +15,15 @@ class FormBuilderViewModel
      */
     public function storageData(int $donationFormId): array
     {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::find($donationFormId);
+
         return [
             'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $donationFormId),
-            'previewURL' => site_url("?givewp-view=donation-form&form-id=$donationFormId"),
+            'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($donationFormId),
             'nonce' => wp_create_nonce('wp_rest'),
-            'blockData' => get_post($donationFormId)->post_content,
-            'settings' => get_post_meta($donationFormId, 'formBuilderSettings', true),
+            'blockData' => $donationForm->blocks->toJson(),
+            'settings' => json_encode($donationForm->settings),
             'currency' => give_get_currency(),
             'formDesigns' => array_map(static function ($designClass) {
                 /** @var FormDesign $design */

--- a/src/NextGen/DonationForm/Actions/ConvertQueryDataToDonationForm.php
+++ b/src/NextGen/DonationForm/Actions/ConvertQueryDataToDonationForm.php
@@ -4,6 +4,7 @@ namespace Give\NextGen\DonationForm\Actions;
 
 use Give\Framework\Support\Facades\DateTime\Temporal;
 use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\ValueObjects\DonationFormMetaKeys;
 use Give\NextGen\DonationForm\ValueObjects\DonationFormStatus;
 use Give\NextGen\Framework\Blocks\BlockCollection;
@@ -23,7 +24,7 @@ class ConvertQueryDataToDonationForm
             'createdAt' => Temporal::toDateTime($queryObject->createdAt),
             'updatedAt' => Temporal::toDateTime($queryObject->updatedAt),
             'status' => new DonationFormStatus($queryObject->status),
-            'settings' => json_decode($queryObject->{DonationFormMetaKeys::SETTINGS()->getKeyAsCamelCase()}, true),
+            'settings' => FormSettings::fromjson($queryObject->{DonationFormMetaKeys::SETTINGS()->getKeyAsCamelCase()}),
             'blocks' => BlockCollection::fromJson($queryObject->blocks)
         ]);
     }

--- a/src/NextGen/DonationForm/Actions/GenerateDonationFormPreviewRouteUrl.php
+++ b/src/NextGen/DonationForm/Actions/GenerateDonationFormPreviewRouteUrl.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Give\NextGen\DonationForm\Actions;
+
+
+/**
+ * @unreleased
+ */
+class GenerateDonationFormPreviewRouteUrl
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(int $formId): string
+    {
+        $args = [
+            'givewp-view' => 'donation-form-preview',
+            'form-id' => $formId
+        ];
+
+        return esc_url(
+            add_query_arg(
+                $args,
+                site_url()
+            )
+        );
+    }
+}

--- a/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
+++ b/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
@@ -2,29 +2,15 @@
 
 namespace Give\NextGen\DonationForm\Controllers;
 
-use Give\Framework\EnqueueScript;
+use Give\NextGen\DonationForm\DataTransferObjects\DonationFormPreviewRouteData;
 use Give\NextGen\DonationForm\DataTransferObjects\DonationFormViewRouteData;
 use Give\NextGen\DonationForm\Models\DonationForm;
-use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
 use Give\NextGen\DonationForm\ViewModels\DonationFormViewModel;
-use Give\NextGen\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 
 class DonationFormViewController
 {
     /**
      * This renders the donation form view.
-     *
-     * This is the order of loading:
-     * 1. Enqueue global styles from WP.
-     *  - This ensures template compatability with global WP css variables as needed. Loads before our templates, so they can use things like global font-family, etc.
-     * 2. Enqueue our donation form specific scripts & styles.
-     *  - We will let WP handle the actual printing depending on how they were enqueued.
-     * 3. Call the specific WP functions wp_print_styles() and wp_print_head_scripts()
-     *  - This will only print the styles and scripts that are enqueued within our route - so we don't have to dequeue a bunch of stuff.
-     * 4. Manually echo our window data and root div for our React app to consume
-     * 5. Finally, call the specific WP function wp_print_footer_scripts()
-     *  - This will only print the footer scripts that are enqueued within our route.
-     *
      *
      * @unreleased
      */
@@ -35,121 +21,29 @@ class DonationFormViewController
 
         $viewModel = new DonationFormViewModel(
             $donationForm->id,
+            $donationForm->blocks,
+            $donationForm->settings
+        );
+
+        return $viewModel->render();
+    }
+
+    /**
+     * This renders the donation form preview
+     *
+     * @unreleased
+     */
+    public function preview(DonationFormPreviewRouteData $data): string
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::find($data->formId);
+
+        $viewModel = new DonationFormViewModel(
+            $donationForm->id,
             $data->formBlocks ?: $donationForm->blocks,
             array_merge($donationForm->settings, $data->formSettings)
         );
 
-        wp_enqueue_global_styles();
-
-        $this->enqueueFormScripts(
-            $data->formId,
-            $viewModel->designId()
-        );
-
-        ob_start();
-        wp_print_styles();
-        wp_print_head_scripts();
-        ?>
-
-        <script>
-            window.giveNextGenExports = <?= wp_json_encode($viewModel->exports()) ?>;
-        </script>
-
-        <div
-            id="root-give-next-gen-donation-form-block"
-            class="givewp-donation-form-block"
-            style="
-                --give-primary-color:<?= $viewModel->primaryColor() ?>;
-                --give-secondary-color:<?= $viewModel->secondaryColor() ?>;
-                "
-        ></div>
-
-        <?php
-        wp_print_footer_scripts();
-        echo ob_get_clean();
-
-        exit();
-    }
-
-    /**
-     * Loads scripts in order: [Registrars, Designs, Gateways, Block]
-     *
-     * @unreleased
-     *
-     * @return void
-     */
-    private function enqueueFormScripts(int $formId, string $formDesignId)
-    {
-        /** @var DonationFormRepository $donationFormRepository */
-        $donationFormRepository = give(DonationFormRepository::class);
-
-        // load registrars
-        (new EnqueueScript(
-            'givewp-donation-form-registrars-js',
-            'build/donationFormRegistrars.js',
-            GIVE_NEXT_GEN_DIR,
-            GIVE_NEXT_GEN_URL,
-            'give'
-        ))->loadInFooter()->enqueue();
-
-        // load template
-        /** @var FormDesignRegistrar $formDesignRegistrar */
-        $formDesignRegistrar = give(FormDesignRegistrar::class);
-
-        // silently fail if design is missing for some reason
-        if ($formDesignRegistrar->hasDesign($formDesignId)) {
-            $design = $formDesignRegistrar->getDesign($formDesignId);
-
-            if ($design->css()) {
-                wp_enqueue_style('givewp-form-design-' . $design::id(), $design->css());
-            }
-
-            if ($design->js()) {
-                wp_enqueue_script(
-                    'givewp-form-design-' . $design::id(),
-                    $design->js(),
-                    array_merge(
-                        ['givewp-donation-form-registrars-js'],
-                        $design->dependencies()
-                    ),
-                    false,
-                    true
-                );
-            }
-        }
-
-        // load gateways
-        foreach ($donationFormRepository->getEnabledPaymentGateways($formId) as $gateway) {
-            if (method_exists($gateway, 'enqueueScript')) {
-                /** @var EnqueueScript $script */
-                $script = $gateway->enqueueScript();
-
-                $script->dependencies(['givewp-donation-form-registrars-js'])
-                    ->loadInFooter()
-                    ->enqueue();
-            }
-        }
-
-        // load block - since this is using render_callback viewScript in blocks.json will not work.
-        (new EnqueueScript(
-            'givewp-next-gen-donation-form-block-js',
-            'build/donationFormBlockApp.js',
-            GIVE_NEXT_GEN_DIR,
-            GIVE_NEXT_GEN_URL,
-            'give'
-        ))->dependencies(['givewp-donation-form-registrars-js'])->loadInFooter()->enqueue();
-
-        /**
-         * Load iframeResizer.contentWindow.min.js inside iframe
-         *
-         * @see https://github.com/davidjbradshaw/iframe-resizer
-         */
-        (new EnqueueScript(
-            'givewp-donation-form-embed-inside',
-            'build/donationFormEmbedInside.js',
-            GIVE_NEXT_GEN_DIR,
-            GIVE_NEXT_GEN_URL,
-            'give'
-        ))->loadInFooter()->enqueue();
+        return $viewModel->render();
     }
 }

--- a/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
+++ b/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
@@ -37,11 +37,17 @@ class DonationFormViewController
     {
         /** @var DonationForm $donationForm */
         $donationForm = DonationForm::find($data->formId);
+        
+        if ($data->formSettings) {
+            foreach ($data->formSettings->toArray() as $key => $value) {
+                $donationForm->settings->{$key} = $value;
+            }
+        }
 
         $viewModel = new DonationFormViewModel(
             $donationForm->id,
             $data->formBlocks ?: $donationForm->blocks,
-            array_merge($donationForm->settings, $data->formSettings)
+            $donationForm->settings
         );
 
         return $viewModel->render();

--- a/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
+++ b/src/NextGen/DonationForm/Controllers/DonationFormViewController.php
@@ -37,17 +37,11 @@ class DonationFormViewController
     {
         /** @var DonationForm $donationForm */
         $donationForm = DonationForm::find($data->formId);
-        
-        if ($data->formSettings) {
-            foreach ($data->formSettings->toArray() as $key => $value) {
-                $donationForm->settings->{$key} = $value;
-            }
-        }
 
         $viewModel = new DonationFormViewModel(
             $donationForm->id,
             $data->formBlocks ?: $donationForm->blocks,
-            $donationForm->settings
+            $data->formSettings ?: $donationForm->settings
         );
 
         return $viewModel->render();

--- a/src/NextGen/DonationForm/DataTransferObjects/DonationFormGoalData.php
+++ b/src/NextGen/DonationForm/DataTransferObjects/DonationFormGoalData.php
@@ -3,8 +3,9 @@
 namespace Give\NextGen\DonationForm\DataTransferObjects;
 
 use Give\Framework\Support\Contracts\Arrayable;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
-use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
 
 /**
  * @unreleased
@@ -24,7 +25,7 @@ class DonationFormGoalData implements Arrayable
      */
     public $isEnabled;
     /**
-     * @var GoalTypeOptions
+     * @var GoalType
      */
     public $goalType;
     /**
@@ -35,13 +36,13 @@ class DonationFormGoalData implements Arrayable
     /**
      * @unreleased
      */
-    public function __construct(int $formId, array $formSettings)
+    public function __construct(int $formId, FormSettings $formSettings)
     {
         $this->formId = $formId;
         $this->formSettings = $formSettings;
-        $this->isEnabled = $formSettings['enableDonationGoal'] ?? false;
-        $this->goalType = new GoalTypeOptions($formSettings['goalType'] ?? GoalTypeOptions::AMOUNT);
-        $this->targetAmount = $this->formSettings['goalAmount'] ?? 0;
+        $this->isEnabled = $formSettings->enableDonationGoal ?? false;
+        $this->goalType = $formSettings->goalType ?? GoalType::AMOUNT();
+        $this->targetAmount = $this->formSettings->goalAmount ?? 0;
     }
 
     /**

--- a/src/NextGen/DonationForm/DataTransferObjects/DonationFormPreviewRouteData.php
+++ b/src/NextGen/DonationForm/DataTransferObjects/DonationFormPreviewRouteData.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Give\NextGen\DonationForm\DataTransferObjects;
+
+use Give\NextGen\Framework\Blocks\BlockCollection;
+
+/**
+ * @unreleased
+ */
+class DonationFormPreviewRouteData
+{
+    /**
+     * @var int
+     */
+    public $formId;
+
+    /**
+     * @var BlockCollection|null
+     */
+    public $formBlocks;
+
+    /**
+     * @var array
+     */
+    public $formSettings;
+
+    /**
+     * Convert data from request into DTO
+     *
+     * @param  array{form-id: string, form-settings: string, form-blocks: string}  $request
+     *
+     * @unreleased
+     */
+    public static function fromRequest(array $request): self
+    {
+        $self = new static();
+
+        $self->formId = (int)$request['form-id'];
+        $self->formSettings = !empty($request['form-settings']) ? json_decode($request['form-settings'], true) : [];
+        $self->formBlocks = !empty($request['form-blocks']) ? BlockCollection::fromJson(
+            $request['form-blocks']
+        ) : null;
+
+        return $self;
+    }
+}

--- a/src/NextGen/DonationForm/DataTransferObjects/DonationFormPreviewRouteData.php
+++ b/src/NextGen/DonationForm/DataTransferObjects/DonationFormPreviewRouteData.php
@@ -2,6 +2,7 @@
 
 namespace Give\NextGen\DonationForm\DataTransferObjects;
 
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\Framework\Blocks\BlockCollection;
 
 /**
@@ -20,7 +21,7 @@ class DonationFormPreviewRouteData
     public $formBlocks;
 
     /**
-     * @var array
+     * @var FormSettings|null
      */
     public $formSettings;
 
@@ -36,7 +37,9 @@ class DonationFormPreviewRouteData
         $self = new static();
 
         $self->formId = (int)$request['form-id'];
-        $self->formSettings = !empty($request['form-settings']) ? json_decode($request['form-settings'], true) : [];
+        $self->formSettings = !empty($request['form-settings']) ? FormSettings::fromJson(
+            $request['form-settings']
+        ) : null;
         $self->formBlocks = !empty($request['form-blocks']) ? BlockCollection::fromJson(
             $request['form-blocks']
         ) : null;

--- a/src/NextGen/DonationForm/DataTransferObjects/DonationFormViewRouteData.php
+++ b/src/NextGen/DonationForm/DataTransferObjects/DonationFormViewRouteData.php
@@ -2,8 +2,6 @@
 
 namespace Give\NextGen\DonationForm\DataTransferObjects;
 
-use Give\NextGen\Framework\Blocks\BlockCollection;
-
 /**
  * @unreleased
  */
@@ -15,19 +13,6 @@ class DonationFormViewRouteData
     public $formId;
 
     /**
-     * @var BlockCollection|null
-     */
-    public $formBlocks;
-
-    /**
-     * @var array
-     */
-    public $formSettings;
-
-    /**
-     * Convert data from request into DTO
-     *
-     * @param  array{form-id: string, form-settings: string, form-blocks: string}  $request
      *
      * @unreleased
      */
@@ -36,10 +21,6 @@ class DonationFormViewRouteData
         $self = new static();
 
         $self->formId = (int)$request['form-id'];
-        $self->formSettings = !empty($request['form-settings']) ? json_decode($request['form-settings'], true) : [];
-        $self->formBlocks = !empty($request['form-blocks']) ? BlockCollection::fromJson(
-            $request['form-blocks']
-        ) : null;
 
         return $self;
     }

--- a/src/NextGen/DonationForm/Factories/DonationFormFactory.php
+++ b/src/NextGen/DonationForm/Factories/DonationFormFactory.php
@@ -3,8 +3,9 @@
 namespace Give\NextGen\DonationForm\Factories;
 
 use Give\Framework\Models\Factories\ModelFactory;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\ValueObjects\DonationFormStatus;
-use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
 use Give\NextGen\Framework\Blocks\BlockCollection;
 
 class DonationFormFactory extends ModelFactory
@@ -19,12 +20,12 @@ class DonationFormFactory extends ModelFactory
         return [
             'title' => __('GiveWP Donation Form', 'give'),
             'status' => DonationFormStatus::PUBLISHED(),
-            'settings' => [
+            'settings' => FormSettings::fromArray([
                 'enableDonationGoal' => false,
                 'goalAmount' => $this->faker->numberBetween(100, 5000),
                 'enableAutoClose' => false,
                 'registration' => 'none',
-                'goalType' => GoalTypeOptions::AMOUNT,
+                'goalType' => GoalType::AMOUNT(),
                 'designId' => 'classic',
                 'showHeading' => true,
                 'showDescription' => true,
@@ -33,7 +34,7 @@ class DonationFormFactory extends ModelFactory
                     'Help our organization by donating today! All donations go directly to making a difference for our cause.',
                     'give'
                 )
-            ],
+            ]),
             'blocks' => BlockCollection::fromJson($blocksJson),
         ];
     }

--- a/src/NextGen/DonationForm/Models/DonationForm.php
+++ b/src/NextGen/DonationForm/Models/DonationForm.php
@@ -12,6 +12,7 @@ use Give\Framework\Models\Model;
 use Give\Framework\Models\ModelQueryBuilder;
 use Give\NextGen\DonationForm\Actions\ConvertQueryDataToDonationForm;
 use Give\NextGen\DonationForm\Factories\DonationFormFactory;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
 use Give\NextGen\DonationForm\ValueObjects\DonationFormStatus;
 use Give\NextGen\Framework\Blocks\BlockCollection;
@@ -24,7 +25,7 @@ use Give\NextGen\Framework\Blocks\BlockCollection;
  * @property DateTime $createdAt
  * @property DateTime $updatedAt
  * @property DonationFormStatus $status
- * @property array $settings
+ * @property FormSettings $settings
  * @property BlockCollection $blocks
  */
 class DonationForm extends Model implements ModelCrud, ModelHasFactory
@@ -38,7 +39,7 @@ class DonationForm extends Model implements ModelCrud, ModelHasFactory
         'createdAt' => DateTime::class,
         'updatedAt' => DateTime::class,
         'status' => DonationFormStatus::class,
-        'settings' => 'array',
+        'settings' => FormSettings::class,
         'blocks' => BlockCollection::class,
     ];
 

--- a/src/NextGen/DonationForm/Properties/FormSettings.php
+++ b/src/NextGen/DonationForm/Properties/FormSettings.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Give\NextGen\DonationForm\Properties;
+
+use Give\Framework\Support\Contracts\Arrayable;
+use Give\Framework\Support\Contracts\Jsonable;
+use Give\NextGen\DonationForm\FormDesigns\ClassicFormDesign\ClassicFormDesign;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
+
+class FormSettings implements Arrayable, Jsonable {
+    /**
+     * @var boolean
+     */
+    public $showHeading;
+    /**
+     * @var boolean
+     */
+    public $showDescription;
+    /**
+     * @var string
+     */
+    public $formTitle;
+    /**
+     * @var boolean
+     */
+    public $enableDonationGoal;
+    /**
+     * @var boolean
+     */
+    public $enableAutoClose;
+    /**
+     * @var GoalType
+     */
+    public $goalType;
+    /**
+     * @var string
+     */
+    public $designId;
+    /**
+     * @var string
+     */
+    public $heading;
+    /**
+     * @var string
+     */
+    public $description;
+    /**
+     * @var string
+     */
+    public $primaryColor;
+    /**
+     * @var string
+     */
+    public $secondaryColor;
+    /**
+     * @var float
+     */
+    public $goalAmount;
+    /**
+     * @var string
+     */
+    public $registration;
+
+    /**
+     * @unreleased
+     */
+    public static function fromArray(array $array): self
+    {
+        $self = new self();
+
+        $self->showHeading = $array['showHeading'] ?? true;
+        $self->heading = $array['heading'] ?? __('Support Our Cause', 'give');
+        $self->showDescription = $array['showDescription'] ?? true;
+         $self->description = $array['description'] ?? __(
+            'Help our organization by donating today! Donations go to making a difference for our cause.',
+            'give'
+        );
+        $self->formTitle =  $array['formTitle'] ?? __('Donation Form', 'give');
+        $self->enableDonationGoal = $array['enableDonationGoal'] ?? false;
+        $self->enableAutoClose = $array['enableAutoClose'] ?? false;
+        $self->goalType = !empty($array['goalType']) ? new GoalType($array['goalType']) : GoalType::AMOUNT();
+        $self->designId = $array['designId'] ?? ClassicFormDesign::id();
+        $self->primaryColor = $array['primaryColor'] ?? '#69b86b';
+        $self->secondaryColor = $array['secondaryColor'] ?? '#f49420';
+        $self->goalAmount = $array['goalAmount'] ?? 0;
+        $self->registration = $array['registration'] ?? 'none';
+
+        return $self;
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function fromJson(string $json): self
+    {
+        $self = new self();
+        $array = json_decode($json, true);
+
+        return $self::fromArray($array);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function toJson($options = 0): string
+    {
+        return json_encode(
+            array_merge(
+                $this->toArray(),
+                [
+                    'goalType' => $this->goalType ? $this->goalType->getValue() : null
+                ]
+            )
+        );
+    }
+}

--- a/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
+++ b/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
@@ -103,7 +103,7 @@ class DonationFormRepository
                 ->insert([
                     'form_id' => $donationFormId,
                     'meta_key' => DonationFormMetaKeys::SETTINGS()->getValue(),
-                    'meta_value' => json_encode($donationForm->settings),
+                    'meta_value' => $donationForm->settings->toJson()
                 ]);
         } catch (Exception $exception) {
             DB::query('ROLLBACK');
@@ -159,7 +159,7 @@ class DonationFormRepository
                 ->where('form_id', $donationForm->id)
                 ->where('meta_key', DonationFormMetaKeys::SETTINGS()->getValue())
                 ->update([
-                    'meta_value' => json_encode($donationForm->settings),
+                    'meta_value' => $donationForm->settings->toJson()
                 ]);
         } catch (Exception $exception) {
             DB::query('ROLLBACK');

--- a/src/NextGen/DonationForm/Routes/DonationFormPreviewRoute.php
+++ b/src/NextGen/DonationForm/Routes/DonationFormPreviewRoute.php
@@ -3,12 +3,12 @@
 namespace Give\NextGen\DonationForm\Routes;
 
 use Give\NextGen\DonationForm\Controllers\DonationFormViewController;
-use Give\NextGen\DonationForm\DataTransferObjects\DonationFormViewRouteData;
+use Give\NextGen\DonationForm\DataTransferObjects\DonationFormPreviewRouteData;
 
 /**
  * @unreleased
  */
-class DonationFormViewRoute
+class DonationFormPreviewRoute
 {
     /**
      * @unreleased
@@ -23,10 +23,10 @@ class DonationFormViewRoute
         }
 
         // create DTO from GET or POST request
-        $routeData = DonationFormViewRouteData::fromRequest(give_clean($_GET));
+        $routeData = DonationFormPreviewRouteData::fromRequest(give_clean($_REQUEST));
 
         // let the controller handle the request
-        return give(DonationFormViewController::class)->show($routeData);
+        return give(DonationFormViewController::class)->preview($routeData);
     }
 
     /**
@@ -34,6 +34,6 @@ class DonationFormViewRoute
      */
     private function isViewValid(): bool
     {
-        return isset($_GET['givewp-view']) && $_GET['givewp-view'] === 'donation-form';
+        return isset($_REQUEST['givewp-view']) && $_REQUEST['givewp-view'] === 'donation-form-preview';
     }
 }

--- a/src/NextGen/DonationForm/ServiceProvider.php
+++ b/src/NextGen/DonationForm/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace Give\NextGen\DonationForm;
 use Give\Helpers\Hooks;
 use Give\NextGen\DonationForm\Blocks\DonationFormBlock\Block as DonationFormBlock;
 use Give\NextGen\DonationForm\Routes\DonateRoute;
+use Give\NextGen\DonationForm\Routes\DonationFormPreviewRoute;
 use Give\NextGen\DonationForm\Routes\DonationFormViewRoute;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
 
@@ -29,5 +30,6 @@ class ServiceProvider implements ServiceProviderInterface {
 
         Hooks::addAction('template_redirect', DonateRoute::class);
         Hooks::addAction('template_redirect', DonationFormViewRoute::class);
+        Hooks::addAction('template_redirect', DonationFormPreviewRoute::class);
     }
 }

--- a/src/NextGen/DonationForm/ValueObjects/GoalType.php
+++ b/src/NextGen/DonationForm/ValueObjects/GoalType.php
@@ -7,14 +7,14 @@ use Give\Framework\Support\ValueObjects\Enum;
 /**
  * @unreleased
  *
- * @method static GoalTypeOptions AMOUNT()
- * @method static GoalTypeOptions DONATIONS()
- * @method static GoalTypeOptions DONORS()
+ * @method static GoalType AMOUNT()
+ * @method static GoalType DONATIONS()
+ * @method static GoalType DONORS()
  * @method bool isAmount()
  * @method bool isDonations()
  * @method bool isDonors()
  */
-class GoalTypeOptions extends Enum
+class GoalType extends Enum
 {
     const AMOUNT = 'amount';
     const DONATIONS = 'donations';

--- a/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
+++ b/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
@@ -2,11 +2,13 @@
 
 namespace Give\NextGen\DonationForm\ViewModels;
 
+use Give\Framework\EnqueueScript;
 use Give\NextGen\DonationForm\Actions\GenerateDonateRouteUrl;
 use Give\NextGen\DonationForm\DataTransferObjects\DonationFormGoalData;
 use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
 use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
 use Give\NextGen\Framework\Blocks\BlockCollection;
+use Give\NextGen\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 
 /**
  * @unreleased
@@ -123,5 +125,136 @@ class DonationFormViewModel
                 'stats' => $this->formStatsData()
             ]),
         ];
+    }
+
+    /**
+     * This is the order of loading:
+     * 1. Enqueue global styles from WP.
+     *  - This ensures template compatability with global WP css variables as needed. Loads before our templates, so they can use things like global font-family, etc.
+     * 2. Enqueue our donation form specific scripts & styles.
+     *  - We will let WP handle the actual printing depending on how they were enqueued.
+     * 3. Call the specific WP functions wp_print_styles() and wp_print_head_scripts()
+     *  - This will only print the styles and scripts that are enqueued within our route - so we don't have to dequeue a bunch of stuff.
+     * 4. Manually echo our window data and root div for our React app to consume
+     * 5. Finally, call the specific WP function wp_print_footer_scripts()
+     *  - This will only print the footer scripts that are enqueued within our route.
+     *
+     * @unreleased
+     */
+    public function render(): string
+    {
+        wp_enqueue_global_styles();
+
+        $this->enqueueFormScripts(
+            $this->donationFormId,
+            $this->designId()
+        );
+
+        ob_start();
+        wp_print_styles();
+        wp_print_head_scripts();
+        ?>
+
+        <script>
+            window.giveNextGenExports = <?= wp_json_encode($this->exports()) ?>;
+        </script>
+
+        <div
+            id="root-give-next-gen-donation-form-block"
+            class="givewp-donation-form-block"
+            style="
+                --give-primary-color:<?= $this->primaryColor() ?>;
+                --give-secondary-color:<?= $this->secondaryColor() ?>;
+                "
+        ></div>
+
+        <?php
+        wp_print_footer_scripts();
+
+        echo ob_get_clean();
+
+        exit();
+    }
+
+    /**
+     * Loads scripts in order: [Registrars, Designs, Gateways, Block]
+     *
+     * @unreleased
+     *
+     * @return void
+     */
+    private function enqueueFormScripts(int $formId, string $formDesignId)
+    {
+        /** @var DonationFormRepository $donationFormRepository */
+        $donationFormRepository = give(DonationFormRepository::class);
+
+        // load registrars
+        (new EnqueueScript(
+            'givewp-donation-form-registrars-js',
+            'build/donationFormRegistrars.js',
+            GIVE_NEXT_GEN_DIR,
+            GIVE_NEXT_GEN_URL,
+            'give'
+        ))->loadInFooter()->enqueue();
+
+        // load template
+        /** @var FormDesignRegistrar $formDesignRegistrar */
+        $formDesignRegistrar = give(FormDesignRegistrar::class);
+
+        // silently fail if design is missing for some reason
+        if ($formDesignRegistrar->hasDesign($formDesignId)) {
+            $design = $formDesignRegistrar->getDesign($formDesignId);
+
+            if ($design->css()) {
+                wp_enqueue_style('givewp-form-design-' . $design::id(), $design->css());
+            }
+
+            if ($design->js()) {
+                wp_enqueue_script(
+                    'givewp-form-design-' . $design::id(),
+                    $design->js(),
+                    array_merge(
+                        ['givewp-donation-form-registrars-js'],
+                        $design->dependencies()
+                    ),
+                    false,
+                    true
+                );
+            }
+        }
+
+        // load gateways
+        foreach ($donationFormRepository->getEnabledPaymentGateways($formId) as $gateway) {
+            if (method_exists($gateway, 'enqueueScript')) {
+                /** @var EnqueueScript $script */
+                $script = $gateway->enqueueScript();
+
+                $script->dependencies(['givewp-donation-form-registrars-js'])
+                    ->loadInFooter()
+                    ->enqueue();
+            }
+        }
+
+        // load block - since this is using render_callback viewScript in blocks.json will not work.
+        (new EnqueueScript(
+            'givewp-next-gen-donation-form-block-js',
+            'build/donationFormBlockApp.js',
+            GIVE_NEXT_GEN_DIR,
+            GIVE_NEXT_GEN_URL,
+            'give'
+        ))->dependencies(['givewp-donation-form-registrars-js'])->loadInFooter()->enqueue();
+
+        /**
+         * Load iframeResizer.contentWindow.min.js inside iframe
+         *
+         * @see https://github.com/davidjbradshaw/iframe-resizer
+         */
+        (new EnqueueScript(
+            'givewp-donation-form-embed-inside',
+            'build/donationFormEmbedInside.js',
+            GIVE_NEXT_GEN_DIR,
+            GIVE_NEXT_GEN_URL,
+            'give'
+        ))->loadInFooter()->enqueue();
     }
 }

--- a/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
+++ b/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
@@ -5,8 +5,9 @@ namespace Give\NextGen\DonationForm\ViewModels;
 use Give\Framework\EnqueueScript;
 use Give\NextGen\DonationForm\Actions\GenerateDonateRouteUrl;
 use Give\NextGen\DonationForm\DataTransferObjects\DonationFormGoalData;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
-use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
 use Give\NextGen\Framework\Blocks\BlockCollection;
 use Give\NextGen\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 
@@ -40,7 +41,7 @@ class DonationFormViewModel
     public function __construct(
         int $donationFormId,
         BlockCollection $formBlocks,
-        array $formSettings = []
+        FormSettings $formSettings
     ) {
         $this->donationFormId = $donationFormId;
         $this->formBlocks = $formBlocks;
@@ -53,7 +54,7 @@ class DonationFormViewModel
      */
     public function designId(): string
     {
-        return $this->formSettings['designId'] ?? '';
+        return $this->formSettings->designId ?? '';
     }
 
     /**
@@ -61,7 +62,7 @@ class DonationFormViewModel
      */
     public function primaryColor(): string
     {
-        return $this->formSettings['primaryColor'] ?? '';
+        return $this->formSettings->primaryColor ?? '';
     }
 
     /**
@@ -69,15 +70,15 @@ class DonationFormViewModel
      */
     public function secondaryColor(): string
     {
-        return $this->formSettings['secondaryColor'] ?? '';
+        return $this->formSettings->secondaryColor ?? '';
     }
 
     /**
      * @unreleased
      */
-    private function goalType(): GoalTypeOptions
+    private function goalType(): GoalType
     {
-        return new GoalTypeOptions($this->formSettings['goalType'] ?? GoalTypeOptions::AMOUNT);
+        return $this->formSettings->goalType ?? GoalType::AMOUNT();
     }
 
     /**

--- a/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
+++ b/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
@@ -5,8 +5,9 @@ namespace TestsNextGen\Unit\Actions;
 use Give\Framework\Support\Facades\DateTime\Temporal;
 use Give\NextGen\DonationForm\Actions\ConvertQueryDataToDonationForm;
 use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\ValueObjects\DonationFormStatus;
-use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
 use Give\NextGen\Framework\Blocks\BlockCollection;
 use Give\NextGen\Framework\Blocks\BlockModel;
 use GiveTests\TestCase;
@@ -38,7 +39,7 @@ class ConvertQueryDataToDonationFormTest extends TestCase {
                 'enableDonationGoal' => false,
                 'enableAutoClose' => false,
                 'registration' => 'none',
-                'goalType' => GoalTypeOptions::AMOUNT,
+                'goalType' => GoalType::AMOUNT()->getValue(),
             ]),
             'blocks' =>  $blockCollection->toJson()
         ];
@@ -51,12 +52,12 @@ class ConvertQueryDataToDonationFormTest extends TestCase {
             'createdAt' => Temporal::toDateTime($createdAt),
             'updatedAt' => Temporal::toDateTime($updatedAt),
             'status' => DonationFormStatus::PUBLISHED(),
-            'settings' => [
+            'settings' => FormSettings::fromArray([
                 'enableDonationGoal' => false,
                 'enableAutoClose' => false,
                 'registration' => 'none',
-                'goalType' => GoalTypeOptions::AMOUNT,
-            ],
+                'goalType' => GoalType::AMOUNT(),
+            ]),
             'blocks' => $blockCollection
         ]);
 

--- a/tests/Unit/Actions/GenerateDonationFormPreviewRouteUrlTest.php
+++ b/tests/Unit/Actions/GenerateDonationFormPreviewRouteUrlTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace TestsNextGen\Unit\Actions;
+
+use Give\NextGen\DonationForm\Actions\GenerateDonationFormPreviewRouteUrl;
+use GiveTests\TestCase;
+
+/**
+ * @unreleased
+ */
+class GenerateDonationFormPreviewRouteUrlTest extends TestCase
+{
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testShouldReturnValidUrl()
+    {
+        $viewUrl = (new GenerateDonationFormPreviewRouteUrl())(1);
+
+        $this->assertSame(esc_url(
+            add_query_arg(
+                [
+                    'givewp-view' => 'donation-form-preview',
+                    'form-id' => 1
+                ],
+                site_url()
+            )
+        ), $viewUrl);
+    }
+}

--- a/tests/Unit/DataTransferObjects/DonationFormPreviewRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonationFormPreviewRouteDataTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TestsNextGen\Unit\DataTransferObjects;
+
+use Give\NextGen\DonationForm\DataTransferObjects\DonationFormPreviewRouteData;
+use Give\NextGen\DonationForm\Models\DonationForm;
+use GiveTests\TestCase;
+
+/**
+ * @unreleased
+ */
+class DonationFormPreviewRouteDataTest extends TestCase
+{
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testShouldReturnFormId()
+    {
+        $data = DonationFormPreviewRouteData::fromRequest([
+            'form-id' => '1',
+            'form-template-id' => 'classic',
+        ]);
+
+        $this->assertSame(1, $data->formId);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testShouldReturnFormSettings()
+    {
+        $data = DonationFormPreviewRouteData::fromRequest([
+            'form-id' => '1',
+            'form-settings' => json_encode([
+                'designId' => 'classic',
+            ]),
+        ]);
+
+        $this->assertSame('classic', $data->formSettings['designId']);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testShouldReturnFormBlocks()
+    {
+        $data = DonationFormPreviewRouteData::fromRequest([
+            'form-id' => '1',
+            'form-template-id' => 'classic',
+            'form-blocks' => DonationForm::factory()->definition()['blocks']->toJson(),
+        ]);
+
+        $this->assertEquals(DonationForm::factory()->definition()['blocks'], $data->formBlocks);
+    }
+
+}

--- a/tests/Unit/DataTransferObjects/DonationFormPreviewRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonationFormPreviewRouteDataTest.php
@@ -40,7 +40,7 @@ class DonationFormPreviewRouteDataTest extends TestCase
             ]),
         ]);
 
-        $this->assertSame('classic', $data->formSettings['designId']);
+        $this->assertSame('classic', $data->formSettings->designId);
     }
 
     /**

--- a/tests/Unit/DataTransferObjects/DonationFormViewRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonationFormViewRouteDataTest.php
@@ -3,7 +3,6 @@
 namespace TestsNextGen\Unit\DataTransferObjects;
 
 use Give\NextGen\DonationForm\DataTransferObjects\DonationFormViewRouteData;
-use Give\NextGen\DonationForm\Models\DonationForm;
 use GiveTests\TestCase;
 
 /**
@@ -20,43 +19,8 @@ class DonationFormViewRouteDataTest extends TestCase
     {
         $data = DonationFormViewRouteData::fromRequest([
             'form-id' => '1',
-            'form-template-id' => 'classic',
         ]);
 
         $this->assertSame(1, $data->formId);
     }
-
-    /**
-     * @unreleased
-     *
-     * @return void
-     */
-    public function testShouldReturnFormSettings()
-    {
-        $data = DonationFormViewRouteData::fromRequest([
-            'form-id' => '1',
-            'form-settings' => json_encode([
-                'designId' => 'classic',
-            ]),
-        ]);
-
-        $this->assertSame('classic', $data->formSettings['designId']);
-    }
-
-    /**
-     * @unreleased
-     *
-     * @return void
-     */
-    public function testShouldReturnFormBlocks()
-    {
-        $data = DonationFormViewRouteData::fromRequest([
-            'form-id' => '1',
-            'form-template-id' => 'classic',
-            'form-blocks' => DonationForm::factory()->definition()['blocks']->toJson(),
-        ]);
-
-        $this->assertEquals(DonationForm::factory()->definition()['blocks'], $data->formBlocks);
-    }
-
 }

--- a/tests/Unit/DonationForm/DataTransferObjects/DonationFormGoalDataTest.php
+++ b/tests/Unit/DonationForm/DataTransferObjects/DonationFormGoalDataTest.php
@@ -4,7 +4,7 @@ namespace TestsNextGen\Unit\DonationForm\VieModels;
 
 use Give\NextGen\DonationForm\DataTransferObjects\DonationFormGoalData;
 use Give\NextGen\DonationForm\Models\DonationForm;
-use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
 use GiveTests\TestCase;
 use GiveTests\TestTraits\RefreshDatabase;
 
@@ -21,11 +21,11 @@ class DonationFormGoalDataTest extends TestCase
         $donationForm = DonationForm::factory()->create();
         $donationFormGoalData = new DonationFormGoalData($donationForm->id, $donationForm->settings);
         $currentAmount = $donationFormGoalData->getCurrentAmount();
-        $isEnabled = $donationForm->settings['enableDonationGoal'] ?? false;
-        $goalType = new GoalTypeOptions($donationForm->settings['goalType'] ?? GoalTypeOptions::AMOUNT);
-        $targetAmount = $donationForm->settings['goalAmount'] ?? 0;
+        $isEnabled = $donationForm->settings->enableDonationGoal ?? false;
+        $goalType = $donationForm->settings->goalType ?? GoalType::AMOUNT();
+        $targetAmount = $donationForm->settings->goalAmount ?? 0;
 
-        $this->assertEquals($donationFormGoalData->toArray(),  [
+        $this->assertEquals($donationFormGoalData->toArray(), [
             'type' => $goalType->getValue(),
             'typeIsCount' => !$goalType->isAmount(),
             'typeIsMoney' => $goalType->isAmount(),

--- a/tests/Unit/DonationForm/ViewModels/DonationFormViewModelTest.php
+++ b/tests/Unit/DonationForm/ViewModels/DonationFormViewModelTest.php
@@ -7,7 +7,7 @@ use Give\NextGen\DonationForm\Actions\GenerateDonateRouteUrl;
 use Give\NextGen\DonationForm\DataTransferObjects\DonationFormGoalData;
 use Give\NextGen\DonationForm\Models\DonationForm;
 use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
-use Give\NextGen\DonationForm\ValueObjects\GoalTypeOptions;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
 use Give\NextGen\DonationForm\ViewModels\DonationFormViewModel;
 use GiveTests\TestCase;
 use GiveTests\TestTraits\RefreshDatabase;
@@ -27,7 +27,7 @@ class DonationFormViewModelTest extends TestCase
 
         $donationFormGoalData = new DonationFormGoalData($donationForm->id, $donationForm->settings);
         $totalRevenue = $donationFormRepository->getTotalRevenue($donationForm->id);
-        $goalType = new GoalTypeOptions($donationForm->settings['goalType'] ?? GoalTypeOptions::AMOUNT);
+        $goalType = $donationForm->settings->goalType ?? GoalType::AMOUNT();
         $donateUrl = (new GenerateDonateRouteUrl())();
         $formDataGateways = $donationFormRepository->getFormDataGateways($donationForm->id);
         $formApi = $donationFormRepository->getFormSchemaFromBlocks(

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -5,6 +5,7 @@ namespace TestsNextGen\Unit\VieModels;
 use Exception;
 use Give\FormBuilder\ValueObjects\FormBuilderRestRouteConfig;
 use Give\FormBuilder\ViewModels\FormBuilderViewModel;
+use Give\NextGen\DonationForm\Actions\GenerateDonationFormPreviewRouteUrl;
 use Give\NextGen\DonationForm\Models\DonationForm;
 use GiveTests\TestCase;
 use GiveTests\TestTraits\RefreshDatabase;
@@ -29,7 +30,7 @@ class FormBuilderViewModelTest extends TestCase
         $this->assertArraySubset(
             [
                 'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $formId),
-                'previewURL' => site_url("?givewp-view=donation-form&form-id=$formId"),
+                'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($formId),
                 'nonce' => wp_create_nonce('wp_rest'),
                 'blockData' => get_post($formId)->post_content,
                 'settings' => get_post_meta($formId, 'formBuilderSettings', true),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR separates the donation form's preview route and render route.  Essentially this means the preview route will accept params that can override the form's rendering logic for previewing changes, while the render route is confined to _only_  what's stored in the database using donation form ID.

Along with the new route, the Donation Form's `settings` property was updated with a new `FormSettings` property.  Everywhere that property was previously being used as an array has now been updated to the new api.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form builder preview route and form settings property.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Just make sure the preview, settings, and block rendering works as expected.  There should be no visual change or issues.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

