### PR TITLE
Feature: Add Goal Achieved Message setting

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,3 +11,4 @@ jobs:
         uses: impress-org/givewp-github-actions/.github/workflows/addon-tests.yml@master
         with:
             addon_slug: givewp-next-gen
+            givewp_branch: develop

--- a/packages/form-builder/src/App.tsx
+++ b/packages/form-builder/src/App.tsx
@@ -22,6 +22,7 @@ const initialState = {
         enableAutoClose: false,
         registration: 'none',
         goalType: 'amount',
+        goalAchievedMessage: __('Thank you to all our donors, we have met our fundraising goal.', 'give'),
         designId: 'classic',
         showHeading: true,
         showDescription: true,

--- a/packages/form-builder/src/settings/donation-goal/index.js
+++ b/packages/form-builder/src/settings/donation-goal/index.js
@@ -4,14 +4,14 @@ import {
     __experimentalNumberControl as NumberControl,
     PanelBody,
     PanelRow,
-    SelectControl,
+    SelectControl, TextareaControl,
     ToggleControl,
 } from '@wordpress/components';
 import debounce from 'lodash.debounce';
 
 const DonationGoalSettings = () => {
     const {
-        settings: {enableDonationGoal, enableAutoClose, goalType, goalAmount},
+        settings: {enableDonationGoal, enableAutoClose, goalAchievedMessage, goalType, goalAmount},
     } = useFormState();
     const dispatch = useFormStateDispatch();
 
@@ -56,6 +56,15 @@ const DonationGoalSettings = () => {
                             onChange={() => dispatch(setFormSettings({enableAutoClose: !enableAutoClose}))}
                         />
                     </PanelRow>
+                    { enableAutoClose && (
+                        <PanelRow>
+                            <TextareaControl
+                                label={__('Goal Achieved Message', 'give')}
+                                value={goalAchievedMessage}
+                                onChange={(goalAchievedMessage) => dispatch(setFormSettings({goalAchievedMessage: goalAchievedMessage}))}
+                            />
+                        </PanelRow>
+                    )}
                     <PanelRow>
                         <SelectControl
                             label={__('Goal Type', 'give')}

--- a/packages/form-builder/src/types/formSettings.ts
+++ b/packages/form-builder/src/types/formSettings.ts
@@ -7,6 +7,7 @@ export type FormSettings = {
     formTitle: string;
     enableDonationGoal: boolean;
     enableAutoClose: boolean;
+    goalAchievedMessage: string;
     registration: string;
     goalType: string;
     designId: string;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a `goalAchievedMessage` setting to the form builder as a Donation Goal setting.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/207676000-bad8095e-cb3a-49ba-9040-bc275518ce64.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Enable Donation Goals
- Enable Auto-Close Form
- Update the Goal Achieved Message
