### PR TITLE
Fix: Set consistent border below tab group

### DIFF
--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -349,11 +349,15 @@ svg {
 /** ------------------------------- */
 
 /*
-Add top border to block card (block tab) to match panel body elements.
+Add border bottom to tabs, while removing body top border.
 This creates a consistent separator between the tabs and the rest of the sidebar.
 */
-.block-editor-block-card {
-    border-top: 1px solid #e0e0e0;
+.components-tab-panel__tabs {
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.components-panel__body {
+    border-top: none;
 }
 
 /** ------------------------------- */

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -347,3 +347,13 @@ svg {
 }
 
 /** ------------------------------- */
+
+/*
+Add top border to block card (block tab) to match panel body elements.
+This creates a consistent separator between the tabs and the rest of the sidebar.
+*/
+.block-editor-block-card {
+    border-bottom: 1px solid #e0e0e0;
+}
+
+/** ------------------------------- */

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -353,7 +353,7 @@ Add top border to block card (block tab) to match panel body elements.
 This creates a consistent separator between the tabs and the rest of the sidebar.
 */
 .block-editor-block-card {
-    border-bottom: 1px solid #e0e0e0;
+    border-top: 1px solid #e0e0e0;
 }
 
 /** ------------------------------- */


### PR DESCRIPTION
## Description

This PR adds a top border to the `block-card` element, when the Block tab is selected, so that the border separator is consistent with the other tabs.

## Visuals

| Form Tab | Block Tab (before) | Block Tab (after) |
|---|---|---|
|![image](https://user-images.githubusercontent.com/10858303/209176384-518c516c-058c-407e-b586-93583cef548f.png)|![image](https://user-images.githubusercontent.com/10858303/209176445-530355c7-e14b-4fb9-b15d-5e2f8aa09b9e.png)|![image](https://user-images.githubusercontent.com/10858303/209176885-5934e86e-b785-4ac8-a2f4-17425e1d1b96.png)|
