### PR TITLE
Refactor: Update CSS Custom Properties prefix to --givewp

### DIFF
--- a/packages/form-builder/CONTRIBUTING.md
+++ b/packages/form-builder/CONTRIBUTING.md
@@ -45,11 +45,11 @@ Globally applicable values should be applied using [CSS custom properties](https
 ```css
 # Definition
 :root {
-  --give-green-brand: #68BF6B;
+  --givewp-green-brand: #68BF6B;
 }
 
 # Usage
 element {
-  background-color: var(--give-green-brand);
+  background-color: var(--givewp-green-brand);
 }
 ```

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -1,54 +1,54 @@
 #root {
     // Gutenberg color mappings
-    --wp-admin-theme-color: var(--give-primary-500);
-    --wp-admin-theme-color--rgb: var(--give-primary-500--rgb);
-    --wp-admin-theme-color-darker-10: var(--give-primary-700);
-    --wp-admin-theme-color-darker-10--rgb: var(--give-primary-700--rgb);
-    --wp-admin-theme-color-darker-20: var(--give-primary-800);
-    --wp-admin-theme-color-darker-20--rgb: var(--give-primary-800--rgb);
+    --wp-admin-theme-color: var(--givewp-primary-500);
+    --wp-admin-theme-color--rgb: var(--givewp-primary-500--rgb);
+    --wp-admin-theme-color-darker-10: var(--givewp-primary-700);
+    --wp-admin-theme-color-darker-10--rgb: var(--givewp-primary-700--rgb);
+    --wp-admin-theme-color-darker-20: var(--givewp-primary-800);
+    --wp-admin-theme-color-darker-20--rgb: var(--givewp-primary-800--rgb);
     --wp-admin-border-width-focus: 2px;
 
     // Layout
-    --give-sidebar-width: 284px;
+    --givewp-sidebar-width: 284px;
 
     // Primary
-    --give-primary-200: #E6FFE6;
-    --give-primary-300: #C2F2C3;
-    --give-primary-400: #AAF2AC;
-    --give-primary-500: #68BF6B;
-    --give-primary-600: #15AE56;
-    --give-primary-700: #5BA65E;
-    --give-primary-800: #3F7341;
+    --givewp-primary-200: #E6FFE6;
+    --givewp-primary-300: #C2F2C3;
+    --givewp-primary-400: #AAF2AC;
+    --givewp-primary-500: #68BF6B;
+    --givewp-primary-600: #15AE56;
+    --givewp-primary-700: #5BA65E;
+    --givewp-primary-800: #3F7341;
 
     // Primary RGB
-    --give-primary-500--rgb: 104, 191, 107;
-    --give-primary-700--rgb: 91, 166, 94;
-    --give-primary-800--rgb: 653, 115, 65;
+    --givewp-primary-500--rgb: 104, 191, 107;
+    --givewp-primary-700--rgb: 91, 166, 94;
+    --givewp-primary-800--rgb: 653, 115, 65;
 
     // Gray
-    --give-gray-10: #F2F2F2;
-    --give-gray-20: #E6E6E6;
-    --give-gray-30: #D9D9D9;
-    --give-gray-40: #BFBFBF;
-    --give-gray-60: #8C8C8C;
-    --give-gray-80: #595959;
-    --give-gray-100: #1E1E1E;
+    --givewp-gray-10: #F2F2F2;
+    --givewp-gray-20: #E6E6E6;
+    --givewp-gray-30: #D9D9D9;
+    --givewp-gray-40: #BFBFBF;
+    --givewp-gray-60: #8C8C8C;
+    --givewp-gray-80: #595959;
+    --givewp-gray-100: #1E1E1E;
 
     // Neutral
-    --give-neutral-70: #B8C6CC;
-    --give-neutral-80: #8FA8B3;
-    --give-neutral-90: #6B8B99;
-    --give-neutral-100: #3D5A66;
-    --give-neutral-110: #233740;
-    --give-neutral-120: #0D161A;
+    --givewp-neutral-70: #B8C6CC;
+    --givewp-neutral-80: #8FA8B3;
+    --givewp-neutral-90: #6B8B99;
+    --givewp-neutral-100: #3D5A66;
+    --givewp-neutral-110: #233740;
+    --givewp-neutral-120: #0D161A;
 
     // Alert
-    --give-alert-10: #DC1E1E;
-    --give-alert-20: #FFE6E6;
-    --give-alert-40: #F5BEBE;
-    --give-alert-60: #E99090;
-    --give-alert-80: #DB5454;
-    --give-alert-100: #DC1E1E;
+    --givewp-alert-10: #DC1E1E;
+    --givewp-alert-20: #FFE6E6;
+    --givewp-alert-40: #F5BEBE;
+    --givewp-alert-60: #E99090;
+    --givewp-alert-80: #DB5454;
+    --givewp-alert-100: #DC1E1E;
 }
 
 body {
@@ -89,7 +89,7 @@ svg {
     width: 100%;
     height: 100vh;
     //margin: 0 250px;
-    background-color: var(--give-gray-10);
+    background-color: var(--givewp-gray-10);
 }
 
 .interface-interface-skeleton__content {
@@ -110,11 +110,11 @@ svg {
         inline-size: 100%;
         padding: 16px;
 
-        border: 1px solid var(--give-neutral-110) !important;
+        border: 1px solid var(--givewp-neutral-110) !important;
         border-radius: 5px;
 
         background-color: #fff;
-        color: var(--give-gray-60) !important;
+        color: var(--givewp-gray-60) !important;
         font-size: 16px !important;
         font-weight: normal;
         line-height: 20px;
@@ -132,7 +132,7 @@ svg {
             svg {
                 height: 24px;
                 width: 24px;
-                fill: var(--give-gray-60);
+                fill: var(--givewp-gray-60);
             }
         }
     }
@@ -145,12 +145,12 @@ svg {
     .components-input-control__label {
         font-size: 16px;
         font-weight: 500;
-        color: var(--give-gray-100);
+        color: var(--givewp-gray-100);
     }
 
     .give-is-required .components-base-control__label::after {
         content: ' *';
-        color: var(--give-alert-100);
+        color: var(--givewp-alert-100);
     }
 }
 
@@ -213,10 +213,10 @@ svg {
         }
 
         &.is-pressed {
-            background-color: var(--give-neutral-100);
+            background-color: var(--givewp-neutral-100);
 
             &:hover {
-                background-color: var(--give-neutral-110);
+                background-color: var(--givewp-neutral-110);
             }
 
             .components-icon--add {
@@ -303,14 +303,14 @@ svg {
 .components-color-palette__custom-color-dropdown-content {
     .components-popover__content,
     .components-color-picker {
-        border: 1px solid var(--give-gray-40);
+        border: 1px solid var(--givewp-gray-40);
     }
 }
 
 .block-editor-panel-color-gradient-settings__dropdown-content .components-popover__content {
 
     // Move popover color panel out from underneath custom sidebar.
-    margin-right: var(--give-sidebar-width) !important;
+    margin-right: var(--givewp-sidebar-width) !important;
 
     // Remove fieldset border.
     .block-editor-color-gradient-control__fieldset { border: 0; }
@@ -341,7 +341,7 @@ svg {
 .components-modal__screen-overlay {
     z-index: 9999999999;
 
-    &--givewp-custom-css {
+    &--givewpwp-custom-css {
         background-color: transparent;
     }
 }

--- a/packages/form-builder/src/blocks/fields/amount/inspector/delete-button.js
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/delete-button.js
@@ -6,8 +6,8 @@ const DeleteButton = (props) => {
             {...props}
             style={{
                 padding: '8px',
-                color: 'var(--give-alert-10)',
-                background: 'var(--give-alert-20)',
+                color: 'var(--givewp-alert-10)',
+                background: 'var(--givewp-alert-20)',
                 border: 'none',
                 cursor: 'pointer',
                 borderRadius: '2px',

--- a/packages/form-builder/src/blocks/fields/amount/level-buttons.js
+++ b/packages/form-builder/src/blocks/fields/amount/level-buttons.js
@@ -4,9 +4,9 @@ const LevelButton = ({children}) => {
             fontSize: '18px',
             fontWeight: 500,
             padding: '16px',
-            border: '1px solid var(--give-neutral-70)',
+            border: '1px solid var(--givewp-neutral-70)',
             borderRadius: '5px',
-            backgroundColor: 'var(--give-neutral-70)',
+            backgroundColor: 'var(--givewp-neutral-70)',
             cursor: 'pointer',
         }}>{children}</div>
     );

--- a/packages/form-builder/src/blocks/fields/donation-summary.js
+++ b/packages/form-builder/src/blocks/fields/donation-summary.js
@@ -22,9 +22,9 @@ const DonationSummary = {
                         display: 'flex',
                         gap: '16px',
                         flexDirection: 'column',
-                        border: '1px dashed var(--give-gray-100)',
+                        border: '1px dashed var(--givewp-gray-100)',
                         borderRadius: '5px',
-                        backgroundColor: 'var(--give-gray-10)',
+                        backgroundColor: 'var(--givewp-gray-10)',
                     }}>
                         <LineItem label={__('Payment Amount', 'give')}/>
                         <LineItem label={__('Giving Frequency', 'give')}/>
@@ -47,7 +47,7 @@ const LineItem = ({label, style}) => {
     return (
         <div style={{display: 'flex', justifyContent: 'space-between'}}>
             <div {...style}>{label}</div>
-            <div style={{height: '20px', width: '120px', backgroundColor: 'var(--give-gray-30)'}}></div>
+            <div style={{height: '20px', width: '120px', backgroundColor: 'var(--givewp-gray-30)'}}></div>
         </div>
     );
 };

--- a/packages/form-builder/src/blocks/fields/payment-gateways.js
+++ b/packages/form-builder/src/blocks/fields/payment-gateways.js
@@ -17,9 +17,9 @@ const paymentGateways = {
         edit: () => <div style={{
             padding: '24px',
             textAlign: 'center',
-            border: '1px dashed var(--give-gray-100)',
+            border: '1px dashed var(--givewp-gray-100)',
             borderRadius: '5px',
-            backgroundColor: 'var(--give-gray-10)',
+            backgroundColor: 'var(--givewp-gray-10)',
         }}>
             <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
                 <GatewayItem label={__('Test Donation', 'give')} icon={
@@ -58,7 +58,7 @@ const paymentGateways = {
 const GatewayItem = ({label, icon}) => {
     return (
         <div style={{
-            backgroundColor: 'var(--give-gray-20)', padding: '16px', display: 'flex', justifyContent: 'space-between',
+            backgroundColor: 'var(--givewp-gray-20)', padding: '16px', display: 'flex', justifyContent: 'space-between',
         }}>
             {label} {icon}
         </div>

--- a/packages/form-builder/src/components/sidebar/panels/field-types-list.js
+++ b/packages/form-builder/src/components/sidebar/panels/field-types-list.js
@@ -62,7 +62,7 @@ const FieldTypesList = () => {
                         <>
                             <h3
                                 style={{
-                                    color: 'var( --give-gray-50 )',
+                                    color: 'var( --givewp-gray-50 )',
                                     margin: '20px',
                                     textTransform: 'uppercase',
                                     fontSize: '.8em',

--- a/packages/form-builder/src/components/sidebar/styles.scss
+++ b/packages/form-builder/src/components/sidebar/styles.scss
@@ -4,7 +4,7 @@
 
     &.givewp-next-gen-sidebar-primary {
         right: 0;
-        width: var(--give-sidebar-width);
+        width: var(--givewp-sidebar-width);
     }
 
     &.givewp-next-gen-sidebar-secondary {

--- a/packages/form-builder/src/feedback/index.tsx
+++ b/packages/form-builder/src/feedback/index.tsx
@@ -33,7 +33,7 @@ const Feedback = () => {
                     <PopupContent>
                         {__('Let us know what you think about the form builder to help improve the product experience.', 'give')}
                         {' '}
-                        <a href={feedbackUrl} target="_blank" rel="noopener noreferrer" onClick={closeCallback} style={{color: 'var(--give-primary-600)'}}>
+                        <a href={feedbackUrl} target="_blank" rel="noopener noreferrer" onClick={closeCallback} style={{color: 'var(--givewp-primary-600)'}}>
                             {__('Click here', 'give')}
                         </a>
                     </PopupContent>

--- a/packages/form-builder/src/feedback/popup/Container.tsx
+++ b/packages/form-builder/src/feedback/popup/Container.tsx
@@ -2,7 +2,7 @@ const Container = ({children}) => {
     return (
         <div style={{
             position: 'relative',
-            border: '1px solid var(--give-gray-30)',
+            border: '1px solid var(--givewp-gray-30)',
             boxShadow: '0px 2px 4px rgba(221, 221, 221, 0.25)',
             borderRadius: '5px',
             backgroundColor: 'white',

--- a/packages/form-builder/src/settings/styles/index.tsx
+++ b/packages/form-builder/src/settings/styles/index.tsx
@@ -39,7 +39,7 @@ const CustomStyleSettings = () => {
                 </div>
 
                 { !! isOpen && (
-                    <Modal overlayClassName="components-modal__screen-overlay--givewp-custom-css" title={ __( 'Custom Styles', 'givewp' ) } onRequestClose={ closeModal } style={{
+                    <Modal overlayClassName="components-modal__screen-overlay--givewpwp-custom-css" title={ __( 'Custom Styles', 'givewp' ) } onRequestClose={ closeModal } style={{
                         height: '100%',
                         maxHeight: '100%', // Override the max height of the modal component.
                         width: '500px',

--- a/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_amount-field.scss
+++ b/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_amount-field.scss
@@ -54,9 +54,9 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        border: 0.125rem solid var(--give-primary-color);
+        border: 0.125rem solid var(--givewp-primary-color);
         border-radius: 0.5rem;
-        background-color: var(--give-primary-color);
+        background-color: var(--givewp-primary-color);
         color: rgb(255, 255, 255);
         text-align: center;
         font-family: inherit;
@@ -84,7 +84,7 @@
 
         &--selected {
             background-color: rgb(255, 255, 255);
-            color: var(--give-primary-color);
+            color: var(--givewp-primary-color);
         }
     }
 }

--- a/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_gateways.scss
+++ b/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_gateways.scss
@@ -41,7 +41,7 @@
         inset-block-start: calc((var(--tab-radio-diameter) - var(--block-size)) / 2 + var(--tab-block-padding));
         font-weight: bold;
         font-size: var(--font-size)/var(--line-height);
-        font-family: var(--give-primary-color);
+        font-family: var(--givewp-primary-color);
         line-height: var(--line-height);
     }
 
@@ -75,7 +75,7 @@
 
         &:hover,
         &:focus {
-            border-color: var(--give-primary-color);
+            border-color: var(--givewp-primary-color);
         }
 
         &:not(:checked) {
@@ -120,14 +120,14 @@
             --diameter: calc(var(--tab-radio-diameter) * 0.4);
             -webkit-margin-start: calc((var(--tab-radio-diameter) - var(--diameter)) / 2 + var(--tab-block-padding));
             margin-inline-start: calc((var(--tab-radio-diameter) - var(--diameter)) / 2 + var(--tab-block-padding));
-            background-color: var(--give-primary-color);
+            background-color: var(--givewp-primary-color);
             opacity: 0;
             transition: opacity var(--tab-transition);
         }
     }
 
     .givewp-fields-payment-gateway {
-        font-family: var(--give-primary-font, inherit), sans-serif;
+        font-family: var(--givewp-primary-font, inherit), sans-serif;
         color: rgb(68, 68, 68);
         list-style: none;
         --tab-radio-diameter: 1.25rem;

--- a/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_goal.scss
+++ b/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_goal.scss
@@ -4,8 +4,8 @@
     }
 
     &-goalAchieved {
-        border: 1px solid var(--give-primary-color);
-        color: var(--give-primary-color);
+        border: 1px solid var(--givewp-primary-color);
+        color: var(--givewp-primary-color);
         border-radius: 0.5rem;
         max-width: min(100%, 51.5rem);
         margin: 0 auto 1px auto;
@@ -51,8 +51,8 @@
             inline-size: clamp(var(--zero-percent), var(--progress), 100%);
             background: linear-gradient(
                     180deg,
-                    var(--give-secondary-color) 0%,
-                    var(--give-secondary-color) 100%
+                    var(--givewp-secondary-color) 0%,
+                    var(--givewp-secondary-color) 100%
             ),
             linear-gradient(180deg, #fff 0%, #ccc 100%);
             background-blend-mode: multiply;

--- a/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_header.scss
+++ b/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_header.scss
@@ -5,7 +5,7 @@
         border-top-left-radius: 0.5rem;
         border-top-right-radius: 0.5rem;
         box-shadow: rgb(0 0 0 / 30%) 0 0.125rem 0.3125rem;
-        background-color: var(--give-primary-color);
+        background-color: var(--givewp-primary-color);
         max-width: min(100%, 51.5rem);
         margin: 0 auto;
         display: grid;
@@ -73,7 +73,7 @@
 .givewp-form-secure-icon {
     position: relative;
     inset-block-start: -0.04em;
-    color: var(--give-secondary-color);
+    color: var(--givewp-secondary-color);
     block-size: 1em;
     aspect-ratio: 1;
     @supports not (aspect-ratio: 1) {

--- a/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/NextGen/DonationForm/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -80,9 +80,9 @@ button[type="submit"] {
     justify-content: center;
     align-items: center;
     padding: 1rem 0;
-    border: 0.125rem solid var(--give-primary-color);
+    border: 0.125rem solid var(--givewp-primary-color);
     border-radius: 0.5rem;
-    background-color: var(--give-primary-color);
+    background-color: var(--givewp-primary-color);
     color: rgb(255, 255, 255);
     text-align: center;
     font-family: inherit;

--- a/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_amount-field.scss
+++ b/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_amount-field.scss
@@ -54,9 +54,9 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        border: 0.125rem solid var(--give-primary-color);
+        border: 0.125rem solid var(--givewp-primary-color);
         border-radius: 0.5rem;
-        //background-color: var(--give-primary-color);
+        //background-color: var(--givewp-primary-color);
         //color: rgb(255, 255, 255);
         text-align: center;
         font-family: inherit;

--- a/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_gateways.scss
+++ b/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_gateways.scss
@@ -41,7 +41,7 @@
         inset-block-start: calc((var(--tab-radio-diameter) - var(--block-size)) / 2 + var(--tab-block-padding));
         font-weight: bold;
         font-size: var(--font-size)/var(--line-height);
-        font-family: var(--give-primary-color);
+        font-family: var(--givewp-primary-color);
         line-height: var(--line-height);
     }
 
@@ -75,7 +75,7 @@
 
         &:hover,
         &:focus {
-            border-color: var(--give-primary-color);
+            border-color: var(--givewp-primary-color);
         }
 
         &:not(:checked) {
@@ -120,14 +120,14 @@
             --diameter: calc(var(--tab-radio-diameter) * 0.4);
             -webkit-margin-start: calc((var(--tab-radio-diameter) - var(--diameter)) / 2 + var(--tab-block-padding));
             margin-inline-start: calc((var(--tab-radio-diameter) - var(--diameter)) / 2 + var(--tab-block-padding));
-            background-color: var(--give-primary-color);
+            background-color: var(--givewp-primary-color);
             opacity: 0;
             transition: opacity var(--tab-transition);
         }
     }
 
     .givewp-fields-payment-gateway {
-        font-family: var(--give-primary-font, inherit), sans-serif;
+        font-family: var(--givewp-primary-font, inherit), sans-serif;
         color: rgb(68, 68, 68);
         list-style: none;
         --tab-radio-diameter: 1.25rem;

--- a/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_goal.scss
+++ b/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_goal.scss
@@ -30,8 +30,8 @@
             inline-size: clamp(var(--zero-percent), var(--progress), 100%);
             background: linear-gradient(
                     180deg,
-                    var(--give-secondary-color) 0%,
-                    var(--give-secondary-color) 100%
+                    var(--givewp-secondary-color) 0%,
+                    var(--givewp-secondary-color) 100%
             ),
             linear-gradient(180deg, #fff 0%, #ccc 100%);
             background-blend-mode: multiply;

--- a/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_inputs.scss
+++ b/src/NextGen/DonationForm/FormDesigns/DeveloperFormDesign/css/_inputs.scss
@@ -79,9 +79,9 @@ button[type="submit"] {
     justify-content: center;
     align-items: center;
     padding: 1rem 0;
-    border: 0.125rem solid var(--give-primary-color);
+    border: 0.125rem solid var(--givewp-primary-color);
     border-radius: 0.5rem;
-    //background-color: var(--give-primary-color);
+    //background-color: var(--givewp-primary-color);
     //color: rgb(255, 255, 255);
     text-align: center;
     font-family: inherit;

--- a/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
+++ b/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
@@ -168,8 +168,8 @@ class DonationFormViewModel
             id="root-givewp-donation-form"
             class="givewp-donation-form"
             style="
-                --give-primary-color:<?= $this->primaryColor() ?>;
-                --give-secondary-color:<?= $this->secondaryColor() ?>;
+                --givewp-primary-color:<?= $this->primaryColor() ?>;
+                --givewp-secondary-color:<?= $this->secondaryColor() ?>;
                 "
         ></div>
 


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates all GiveWP [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) to use the `--givewp` prefix for consistency with the CSS class name prefix.

## Visuals

```diff
-    --give-primary-200: #E6FFE6;
-    --give-primary-300: #C2F2C3;
-    --give-primary-400: #AAF2AC;
-    --give-primary-500: #68BF6B;
-    --give-primary-600: #15AE56;
-    --give-primary-700: #5BA65E;
-    --give-primary-800: #3F7341;
+   --givewp-primary-200: #E6FFE6;
+   --givewp-primary-300: #C2F2C3;
+   --givewp-primary-400: #AAF2AC;
+   --givewp-primary-500: #68BF6B;
+   --givewp-primary-600: #15AE56;
+   --givewp-primary-700: #5BA65E;
+   --givewp-primary-800: #3F7341;
```