### PR TITLE
Refactor: Remove layout margin when not selected

### DIFF
--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -168,10 +168,6 @@ svg {
         gap: 24px;
         flex-direction: column;
     }
-
-    //&.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
-    //    margin-bottom: 40px;
-    //}
 }
 
 [data-type="custom-block-editor/paragraph"] .rich-text {

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -167,6 +167,9 @@ svg {
         display: flex;
         gap: 24px;
         flex-direction: column;
+    }
+
+    &.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
         margin-bottom: 40px;
     }
 }

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -169,9 +169,9 @@ svg {
         flex-direction: column;
     }
 
-    &.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
-        margin-bottom: 40px;
-    }
+    //&.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
+    //    margin-bottom: 40px;
+    //}
 }
 
 [data-type="custom-block-editor/paragraph"] .rich-text {
@@ -180,7 +180,8 @@ svg {
 }
 
 .block-editor-block-list__block .block-list-appender {
-    bottom: -40px;
+    // position the button 1 below itself and then half inside the padding. (24px is the size of the button and 36px is the padding bottom)
+    bottom: calc(-24px + calc((36px - 24px) / -2));
     width: 100%;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR removes the extra bottom margin from the section block when not selected. Previously, this bottom margin was added as a placeholder to prevent shifting when the section block was selected and the block appender was rendered in that space.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Before | After |
| --- | --- |
| ![Screenshot from 2022-12-22 11-43-23](https://user-images.githubusercontent.com/10858303/209183858-363cd89d-8bc3-4037-980e-0183c352a65a.png) | ![Screenshot from 2022-12-22 11-44-17](https://user-images.githubusercontent.com/10858303/209183853-80ba38a3-ac79-41f2-bb65-72275a3a3bcd.png)  |




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203547864809100