### PR TITLE
Fix: custom fields backwards compatability

### DIFF
--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -168,10 +168,6 @@ svg {
         gap: 24px;
         flex-direction: column;
     }
-
-    //&.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
-    //    margin-bottom: 40px;
-    //}
 }
 
 [data-type="custom-block-editor/paragraph"] .rich-text {

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -167,6 +167,9 @@ svg {
         display: flex;
         gap: 24px;
         flex-direction: column;
+    }
+
+    &.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
         margin-bottom: 40px;
     }
 }

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -169,9 +169,9 @@ svg {
         flex-direction: column;
     }
 
-    &.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
-        margin-bottom: 40px;
-    }
+    //&.is-selected > div > .block-editor-inner-blocks > .block-editor-block-list__layout {
+    //    margin-bottom: 40px;
+    //}
 }
 
 [data-type="custom-block-editor/paragraph"] .rich-text {
@@ -180,7 +180,8 @@ svg {
 }
 
 .block-editor-block-list__block .block-list-appender {
-    bottom: -40px;
+    // position the button 1 below itself and then half inside the padding. (24px is the size of the button and 36px is the padding bottom)
+    bottom: calc(-24px + calc((36px - 24px) / -2));
     width: 100%;
     display: flex;
     justify-content: center;

--- a/src/NextGen/CustomFields/Controllers/DonationDetailsController.php
+++ b/src/NextGen/CustomFields/Controllers/DonationDetailsController.php
@@ -15,17 +15,17 @@ class DonationDetailsController
     /**
      * @unreleased
      *
-     * @param int $donationID
+     * @param  int  $donationID
      *
-     * @return void
+     * @return string
      */
-    public function show(int $donationID): void
+    public function show(int $donationID): string
     {
         /** @var Donation $donation */
         $donation = Donation::find($donationID);
 
         if (give(DonationFormRepository::class)->isLegacyForm($donation->formId)) {
-            return;
+            return '';
         }
 
         /** @var DonationForm $form */
@@ -35,8 +35,6 @@ class DonationDetailsController
             return $field->shouldDisplayInAdmin() && !$field->shouldStoreAsDonorMeta();
         });
 
-        $view = new DonationDetailsView($donation, $fields);
-
-        echo $view->render();
+        return (new DonationDetailsView($donation, $fields))->render();
     }
 }

--- a/src/NextGen/CustomFields/Controllers/DonationDetailsController.php
+++ b/src/NextGen/CustomFields/Controllers/DonationDetailsController.php
@@ -5,6 +5,7 @@ namespace Give\NextGen\CustomFields\Controllers;
 use Give\Donations\Models\Donation;
 use Give\NextGen\CustomFields\Views\DonationDetailsView;
 use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
 
 /**
  * @unreleased
@@ -20,12 +21,22 @@ class DonationDetailsController
      */
     public function show(int $donationID): void
     {
+        /** @var Donation $donation */
         $donation = Donation::find($donationID);
+
+        if (give(DonationFormRepository::class)->isLegacyForm($donation->formId)) {
+            return;
+        }
+
+        /** @var DonationForm $form */
         $form = DonationForm::find($donation->formId);
-        $fields = array_filter($form->schema()->getFields(), function($field) {
-            return $field->shouldDisplayInAdmin() && ! $field->shouldStoreAsDonorMeta();
+
+        $fields = array_filter($form->schema()->getFields(), static function ($field) {
+            return $field->shouldDisplayInAdmin() && !$field->shouldStoreAsDonorMeta();
         });
+
         $view = new DonationDetailsView($donation, $fields);
+
         echo $view->render();
     }
 }

--- a/src/NextGen/CustomFields/Controllers/DonorDetailsController.php
+++ b/src/NextGen/CustomFields/Controllers/DonorDetailsController.php
@@ -6,7 +6,10 @@ use Give\Donations\Models\Donation;
 use Give\Donors\Models\Donor;
 use Give\NextGen\CustomFields\Views\DonorDetailsView;
 use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
 use Give_Donor as LegacyDonor;
+
+use function array_reduce;
 
 /**
  * @unreleased
@@ -16,38 +19,48 @@ class DonorDetailsController
     /**
      * @unreleased
      *
-     * @param LegacyDonor $legacyDonor
+     * @param  LegacyDonor  $legacyDonor
      *
      * @return void
      */
     public function show(LegacyDonor $legacyDonor): void
     {
+        /** @var Donor $donor */
         $donor = Donor::find($legacyDonor->id);
 
         $forms = $this->getUniqueDonationFormsForDonor($donor);
 
-        $fields = array_reduce($forms, function($fields, DonationForm $form) {
+        if (!$forms) {
+            return;
+        }
+
+        $fields = array_reduce($forms, function ($fields, DonationForm $form) {
             return $fields + $this->getDisplayedDonorMetaFieldsForForm($form);
         }, []);
 
         $view = new DonorDetailsView($donor, $fields);
+
         echo $view->render();
     }
 
     /**
      * @unreleased
      *
-     * @param Donor $donor
+     * @param  Donor  $donor
      *
-     * @return array
+     * @return DonationForm[]
      */
     protected function getUniqueDonationFormsForDonor(Donor $donor): array
     {
-        $formIds = array_map(function(Donation $donation) {
+        $formIds = array_map(static function (Donation $donation) {
             return $donation->formId;
         }, $donor->donations);
 
-        return array_map(function($formId) {
+        $formIds = array_filter($formIds, static function ($formId) {
+            return !give(DonationFormRepository::class)->isLegacyForm($formId);
+        });
+
+        return array_map(static function ($formId) {
             return DonationForm::find($formId);
         }, array_unique($formIds));
     }

--- a/src/NextGen/CustomFields/Controllers/DonorDetailsController.php
+++ b/src/NextGen/CustomFields/Controllers/DonorDetailsController.php
@@ -7,7 +7,6 @@ use Give\Donors\Models\Donor;
 use Give\NextGen\CustomFields\Views\DonorDetailsView;
 use Give\NextGen\DonationForm\Models\DonationForm;
 use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
-use Give_Donor as LegacyDonor;
 
 use function array_reduce;
 
@@ -18,29 +17,20 @@ class DonorDetailsController
 {
     /**
      * @unreleased
-     *
-     * @param  LegacyDonor  $legacyDonor
-     *
-     * @return void
      */
-    public function show(LegacyDonor $legacyDonor): void
+    public function show(Donor $donor): string
     {
-        /** @var Donor $donor */
-        $donor = Donor::find($legacyDonor->id);
-
         $forms = $this->getUniqueDonationFormsForDonor($donor);
 
         if (!$forms) {
-            return;
+            return '';
         }
 
         $fields = array_reduce($forms, function ($fields, DonationForm $form) {
             return $fields + $this->getDisplayedDonorMetaFieldsForForm($form);
         }, []);
 
-        $view = new DonorDetailsView($donor, $fields);
-
-        echo $view->render();
+        return (new DonorDetailsView($donor, $fields))->render();
     }
 
     /**

--- a/src/NextGen/CustomFields/ServiceProvider.php
+++ b/src/NextGen/CustomFields/ServiceProvider.php
@@ -2,11 +2,12 @@
 
 namespace Give\NextGen\CustomFields;
 
+use Give\Donors\Models\Donor;
 use Give\Framework\FieldsAPI\Field;
-use Give\Helpers\Hooks;
 use Give\NextGen\CustomFields\Controllers\DonationDetailsController;
 use Give\NextGen\CustomFields\Controllers\DonorDetailsController;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
+use Give_Donor as LegacyDonor;
 
 /**
  * @unreleased
@@ -32,10 +33,15 @@ class ServiceProvider implements ServiceProviderInterface
      */
     public function boot()
     {
-        Hooks::addAction('give_donor_after_tables', DonorDetailsController::class, 'show');
+        add_action('give_donor_after_tables', static function (LegacyDonor $legacyDonor) {
+            /** @var Donor $donor */
+            $donor = Donor::find($legacyDonor->id);
+            
+            echo (new DonorDetailsController())->show($donor);
+        });
 
         add_action('give_view_donation_details_billing_after', static function ($donationId) {
-            echo give(DonationDetailsController::class)->show($donationId);
+            echo (new DonationDetailsController())->show($donationId);
         });
     }
 }

--- a/src/NextGen/CustomFields/ServiceProvider.php
+++ b/src/NextGen/CustomFields/ServiceProvider.php
@@ -33,6 +33,9 @@ class ServiceProvider implements ServiceProviderInterface
     public function boot()
     {
         Hooks::addAction('give_donor_after_tables', DonorDetailsController::class, 'show');
-        Hooks::addAction('give_view_donation_details_billing_after', DonationDetailsController::class, 'show');
+
+        add_action('give_view_donation_details_billing_after', static function ($donationId) {
+            echo give(DonationDetailsController::class)->show($donationId);
+        });
     }
 }

--- a/src/NextGen/CustomFields/Views/DonationDetailsView.php
+++ b/src/NextGen/CustomFields/Views/DonationDetailsView.php
@@ -19,8 +19,8 @@ class DonationDetailsView
     /**
      * @unreleased
      *
-     * @param Donation      $donation
-     * @param array|Field[] $fields
+     * @param  Donation  $donation
+     * @param  array|Field[]  $fields
      */
     public function __construct(Donation $donation, array $fields)
     {
@@ -35,12 +35,10 @@ class DonationDetailsView
      */
     public function render(): string
     {
-        return "
-        <div class='postbox' style='padding-bottom: 15px;'>
+        return "<div class='postbox' style='padding-bottom: 15px;'>
             <h3 class='handle'>{$this->getTitle()}</h3>
             <div class='inside'>{$this->getContents()}</div>
-        </div>
-        ";
+        </div>";
     }
 
     /**
@@ -50,7 +48,7 @@ class DonationDetailsView
      */
     protected function getTitle(): string
     {
-        return __('Custom Fields', 'givewp');
+        return __('Custom Fields', 'give');
     }
 
     /**
@@ -60,7 +58,7 @@ class DonationDetailsView
      */
     protected function getContents(): string
     {
-        return array_reduce($this->fields, function($output, Field $field) {
+        return array_reduce($this->fields, function ($output, Field $field) {
             return $output . "
                 <div>
                     <strong>{$field->getLabel()}:</strong>&nbsp;
@@ -73,12 +71,12 @@ class DonationDetailsView
     /**
      * @unreleased
      *
-     * @param Field $field
+     * @param  Field  $field
      *
      * @return mixed
      */
     protected function getFieldValue(Field $field)
     {
-        return give()->payment_meta->get_meta($this->donation->id, $field->getName(), true );
+        return give()->payment_meta->get_meta($this->donation->id, $field->getName(), true);
     }
 }

--- a/src/NextGen/CustomFields/Views/DonorDetailsView.php
+++ b/src/NextGen/CustomFields/Views/DonorDetailsView.php
@@ -35,8 +35,7 @@ class DonorDetailsView
      */
     public function render(): string
     {
-        return "
-        <h3>{$this->getTitle()}</h3>
+        return "<h3>{$this->getTitle()}</h3>
         <table class='wp-list-table widefat striped donations'>
 			<thead>
                 <tr>
@@ -47,8 +46,7 @@ class DonorDetailsView
 			<tbody>
 			    {$this->getTableRows()}
             </tbody>
-		</table>
-        ";
+		</table>";
     }
 
     /**
@@ -58,7 +56,7 @@ class DonorDetailsView
      */
     protected function getTitle(): string
     {
-        return __('Custom Fields', 'givewp');
+        return __('Custom Fields', 'give');
     }
 
     /**
@@ -81,12 +79,10 @@ class DonorDetailsView
     /**
      * @unreleased
      *
-     * @param Field $field
-     *
      * @return mixed
      */
     protected function getFieldValue(Field $field)
     {
-        return give()->donor_meta->get_meta($this->donor->userId, $field->getName(), true);
+        return give()->donor_meta->get_meta($this->donor->id, $field->getName(), true);
     }
 }

--- a/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
+++ b/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
@@ -368,4 +368,12 @@ class DonationFormRepository
 
         return $form;
     }
+
+    /**
+     * @unreleased
+     */
+    public function isLegacyForm(int $formId): bool
+    {
+        return !get_post($formId)->post_content;
+    }
 }

--- a/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
+++ b/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
@@ -374,6 +374,8 @@ class DonationFormRepository
      */
     public function isLegacyForm(int $formId): bool
     {
-        return !get_post($formId)->post_content;
+        $form = DB::table('posts')->select(['post_content', 'data'])->where('ID', $formId)->get();
+
+        return !$form->data;
     }
 }

--- a/tests/Unit/CustomFields/Controllers/TestDonationDetailsController.php
+++ b/tests/Unit/CustomFields/Controllers/TestDonationDetailsController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Give\Tests\Unit\CustomFields\Controllers;
+
+use Give\Donations\Models\Donation;
+use Give\Framework\Database\DB;
+use Give\NextGen\CustomFields\Controllers\DonationDetailsController;
+use Give\NextGen\CustomFields\Views\DonationDetailsView;
+use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+class TestDonationDetailsController extends TestCase {
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    public function testShowShouldReturnDonationDetailsViewRendered() {
+        $donationForm = DonationForm::factory()->create();
+
+        $donation = Donation::factory()->create([
+            'formId' => $donationForm->id,
+        ]);
+
+        $controller = new DonationDetailsController();
+
+        $fields = array_filter($donationForm->schema()->getFields(), static function ($field) {
+            return $field->shouldDisplayInAdmin() && !$field->shouldStoreAsDonorMeta();
+        });
+
+        $view = new DonationDetailsView($donation, $fields);
+
+        $this->assertSame($controller->show($donation->id), $view->render());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShowShouldReturnEmptyStringIfDonationFormIsLegacy() {
+
+        $legacyDonationForm = DB::table('posts')->insert([
+            'post_title' => 'Legacy Donation Form',
+            'post_type' => 'give_forms',
+            'post_status' => 'publish',
+        ]);
+
+        $legacyDonationFormId = DB::last_insert_id();
+
+        $donation = Donation::factory()->create([
+            'formId' => $legacyDonationFormId,
+        ]);
+
+        $controller = new DonationDetailsController();
+
+        $this->assertEmpty($controller->show($donation->id));
+    }
+
+}

--- a/tests/Unit/CustomFields/Controllers/TestDonorDetailsController.php
+++ b/tests/Unit/CustomFields/Controllers/TestDonorDetailsController.php
@@ -2,9 +2,67 @@
 
 namespace Give\Tests\Unit\CustomFields\Controllers;
 
+use Exception;
+use Give\Donations\Models\Donation;
+use Give\Donors\Models\Donor;
+use Give\Framework\Database\DB;
+use Give\NextGen\CustomFields\Controllers\DonorDetailsController;
+use Give\NextGen\CustomFields\Views\DonorDetailsView;
+use Give\NextGen\DonationForm\Models\DonationForm;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
-class TestDonorDetailsController extends TestCase {
+class TestDonorDetailsController extends TestCase
+{
     use RefreshDatabase;
+
+    /**
+     * @throws Exception
+     */
+    public function testShowShouldReturnDonorDetailsViewRendered()
+    {
+        $donationForm = DonationForm::factory()->create();
+        $donor = Donor::factory()->create();
+        $donation = Donation::factory()->create([
+            'formId' => $donationForm->id,
+            'donorId' => $donor->id,
+        ]);
+
+        $controller = new DonorDetailsController();
+
+        $fields = array_reduce([$donationForm], static function ($fields, DonationForm $form) {
+            return $fields + array_filter($form->schema()->getFields(), static function ($field) {
+                    return $field->shouldDisplayInAdmin() && $field->shouldStoreAsDonorMeta();
+                });
+        }, []);
+
+        $view = new DonorDetailsView($donor, $fields);
+
+        $this->assertSame($controller->show($donor), $view->render());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShowShouldReturnEmptyIfIsLegacyForm()
+    {
+        $legacyForm = DB::table('posts')->insert([
+            'post_title' => 'Legacy Form',
+            'post_type' => 'give_forms',
+            'post_status' => 'publish',
+        ]);
+
+        $legacyFormId = DB::last_insert_id();
+
+        $donor = Donor::factory()->create();
+
+        $donation = Donation::factory()->create([
+            'formId' => $legacyFormId,
+            'donorId' => $donor->id,
+        ]);
+
+        $controller = new DonorDetailsController();
+
+        $this->assertEmpty($controller->show($donor));
+    }
 }

--- a/tests/Unit/CustomFields/Controllers/TestDonorDetailsController.php
+++ b/tests/Unit/CustomFields/Controllers/TestDonorDetailsController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Give\Tests\Unit\CustomFields\Controllers;
+
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+class TestDonorDetailsController extends TestCase {
+    use RefreshDatabase;
+}

--- a/tests/Unit/CustomFields/Views/TestDonationDetailsView.php
+++ b/tests/Unit/CustomFields/Views/TestDonationDetailsView.php
@@ -2,9 +2,85 @@
 
 namespace Give\Tests\Unit\CustomFields\Views;
 
+use Give\Donations\Models\Donation;
+use Give\NextGen\CustomFields\Views\DonationDetailsView;
+use Give\NextGen\DonationForm\Actions\StoreCustomFields;
+use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\Framework\Blocks\BlockCollection;
+use Give\NextGen\Framework\Blocks\BlockModel;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
-class TestDonationDetailsView extends TestCase {
+use function str_replace;
+
+class TestDonationDetailsView extends TestCase
+{
     use RefreshDatabase;
+
+    public function testRenderShouldReturnCustomFieldsHtml()
+    {
+        /** @var DonationForm $form */
+        $form = DonationForm::factory()->create();
+
+        $customFieldBlockModel = BlockModel::make([
+            'name' => 'custom-block-editor/section',
+            'attributes' => ['title' => '', 'description' => ''],
+            'innerBlocks' => [
+                [
+                    'name' => 'custom-block-editor/custom-text-block',
+                    'attributes' => [
+                        'fieldName' => 'custom_text_block_meta',
+                        'storeAsDonorMeta' => false,
+                        'storeAsDonationMeta' => true,
+                        'displayInAdmin' => true,
+                        'title' => 'Custom Text Field',
+                        'label' => 'Custom Text Field',
+                        'description' => ''
+                    ],
+                ]
+            ]
+        ]);
+
+        $form->blocks = BlockCollection::make(
+            array_merge([$customFieldBlockModel], $form->blocks->getBlocks())
+        );
+
+        $form->save();
+
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create(['formId' => $form->id]);
+
+        (new StoreCustomFields())($form, $donation, ['custom_text_block_meta' => 'Custom Text Block Value']);
+
+        $form = DonationForm::find($form->id);
+
+        $fields = array_filter($form->schema()->getFields(), static function ($field) {
+            return $field->shouldDisplayInAdmin() && !$field->shouldStoreAsDonorMeta();
+        });
+
+        $donationDetailsView = new DonationDetailsView($donation, $fields);
+
+        $mockRender = "<div class='postbox' style='padding-bottom: 15px;'>
+            <h3 class='handle'>Custom Fields</h3>
+            <div class='inside'>
+                <div>
+                    <strong>Custom Text Field:</strong>&nbsp;
+                    Custom Text Block Value
+                </div>
+            </div>
+        </div>";
+
+        $this->assertSame(
+            str_replace(
+                ' ',
+                '',
+                $mockRender
+            ),
+            str_replace(
+                ' ',
+                '',
+                $donationDetailsView->render()
+            )
+        );
+    }
 }

--- a/tests/Unit/CustomFields/Views/TestDonationDetailsView.php
+++ b/tests/Unit/CustomFields/Views/TestDonationDetailsView.php
@@ -11,8 +11,6 @@ use Give\NextGen\Framework\Blocks\BlockModel;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
-use function str_replace;
-
 class TestDonationDetailsView extends TestCase
 {
     use RefreshDatabase;
@@ -71,14 +69,14 @@ class TestDonationDetailsView extends TestCase
         </div>";
 
         $this->assertSame(
-            str_replace(
-                ' ',
-                '',
+            preg_replace(
+                "/\s+/",
+                "",
                 $mockRender
             ),
-            str_replace(
-                ' ',
-                '',
+            preg_replace(
+                "/\s+/",
+                "",
                 $donationDetailsView->render()
             )
         );

--- a/tests/Unit/CustomFields/Views/TestDonationDetailsView.php
+++ b/tests/Unit/CustomFields/Views/TestDonationDetailsView.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Give\Tests\Unit\CustomFields\Views;
+
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+class TestDonationDetailsView extends TestCase {
+    use RefreshDatabase;
+}

--- a/tests/Unit/CustomFields/Views/TestDonorDetailsView.php
+++ b/tests/Unit/CustomFields/Views/TestDonorDetailsView.php
@@ -2,10 +2,94 @@
 
 namespace Give\Tests\Unit\CustomFields\Views;
 
+use Give\Donations\Models\Donation;
+use Give\Donors\Models\Donor;
+use Give\NextGen\CustomFields\Views\DonorDetailsView;
+use Give\NextGen\DonationForm\Actions\StoreCustomFields;
+use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\Framework\Blocks\BlockCollection;
+use Give\NextGen\Framework\Blocks\BlockModel;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
-class TestDonorDetailsView extends TestCase {
+class TestDonorDetailsView extends TestCase
+{
     use RefreshDatabase;
+
+    public function testRenderShouldReturnCustomFieldsHtml()
+    {
+        /** @var Donor $donor */
+        $donor = Donor::factory()->create();
+
+        /** @var DonationForm $form */
+        $form = DonationForm::factory()->create();
+
+        $customFieldBlockModel = BlockModel::make([
+            'name' => 'custom-block-editor/section',
+            'attributes' => ['title' => '', 'description' => ''],
+            'innerBlocks' => [
+                [
+                    'name' => 'custom-block-editor/custom-text-block',
+                    'attributes' => [
+                        'fieldName' => 'custom_text_block_meta',
+                        'storeAsDonorMeta' => true,
+                        'storeAsDonationMeta' => false,
+                        'displayInAdmin' => true,
+                        'title' => 'Custom Text Field',
+                        'label' => 'Custom Text Field',
+                        'description' => ''
+                    ],
+                ]
+            ]
+        ]);
+
+        $form->blocks = BlockCollection::make(
+            array_merge([$customFieldBlockModel], $form->blocks->getBlocks())
+        );
+
+        $form->save();
+
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create(['formId' => $form->id, 'donorId' => $donor->id]);
+
+        (new StoreCustomFields())($form, $donation, ['custom_text_block_meta' => 'Custom Text Block Value']);
+
+        $form = DonationForm::find($form->id);
+
+        $fields = array_filter($form->schema()->getFields(), static function ($field) {
+            return $field->shouldDisplayInAdmin() && $field->shouldStoreAsDonorMeta();
+        });
+
+        $donorDetailsView = new DonorDetailsView($donation->donor, $fields);
+
+        $mockRender = "<h3>Custom Fields</h3>
+        <table class='wp-list-table widefat striped donations'>
+			<thead>
+                <tr>
+                    <th scope='col'>Field</th>
+                    <th scope='col'>Value</th>
+                </tr>
+			</thead>
+			<tbody>
+			    <tr>
+                    <td>Custom Text Field</td>
+                    <td>Custom Text Block Value</td>
+                </tr>
+            </tbody>
+		</table>";
+
+        $this->assertSame(
+            preg_replace(
+                "/\s+/",
+                "",
+                $mockRender
+            ),
+            preg_replace(
+                "/\s+/",
+                "",
+                $donorDetailsView->render()
+            )
+        );
+    }
 
 }

--- a/tests/Unit/CustomFields/Views/TestDonorDetailsView.php
+++ b/tests/Unit/CustomFields/Views/TestDonorDetailsView.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Give\Tests\Unit\CustomFields\Views;
+
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+class TestDonorDetailsView extends TestCase {
+    use RefreshDatabase;
+
+}

--- a/tests/Unit/DonationForm/Repositories/TestDonationFormRepository.php
+++ b/tests/Unit/DonationForm/Repositories/TestDonationFormRepository.php
@@ -213,4 +213,31 @@ final class TestDonationFormRepository extends TestCase
     {
         return $this->markTestIncomplete();
     }
+
+    /**
+     * @unreleased
+     */
+    public function testIsLegacyFormShouldReturnTrueWhenFormIsLegacy()
+    {
+        $legacyForm = DB::table('posts')->insert([
+            'post_title' => 'Legacy Form',
+            'post_type' => 'give_forms',
+            'post_status' => 'publish',
+        ]);
+
+        $legacyFormId = DB::last_insert_id();
+
+        $this->assertTrue($this->repository->isLegacyForm($legacyFormId));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testIsLegacyFormShouldReturnFalseIfNotLegacy()
+    {
+        // create a new form
+        $form = DonationForm::factory()->create();
+
+        $this->assertFalse($this->repository->isLegacyForm($form->id));
+    }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

When viewing donor & donation detail pages who are not associated with a Next Gen form, there are errors for missing data.  This PR updates the logic for displaying custom fields in the detail pages with a check to see if it's a legacy form first before proceeding.

I also wrote a unit test for all the different pieces, so there were some minor tweaks to the logic along the way to make things more testable.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donor & donation detail pages

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->


Before (Donation not using Next Gen Form):

<img width="1432" alt="Screen Shot 2022-12-29 at 11 05 33 AM" src="https://user-images.githubusercontent.com/10138447/209979183-eb8926f5-788e-48d4-a268-b8baef905de2.png">


After (Donation not using Next Gen Form):

<img width="1433" alt="Screen Shot 2022-12-29 at 11 05 54 AM" src="https://user-images.githubusercontent.com/10138447/209979191-a90ab344-747b-47af-b756-53def49c1883.png">

Donation using Next Gen Form (Still works):


<img width="1437" alt="Screen Shot 2022-12-29 at 11 07 50 AM" src="https://user-images.githubusercontent.com/10138447/209979447-efd4e506-f44d-4e1f-a5e2-9ae9abd0474e.png">


Before (Donor not using Next Gen Form):


<img width="1265" alt="Screen Shot 2022-12-29 at 11 12 28 AM" src="https://user-images.githubusercontent.com/10138447/209979976-1cafbd41-7b2d-470d-a33f-5b3a599cb742.png">

After:
<img width="1265" alt="Screen Shot 2022-12-29 at 11 12 39 AM" src="https://user-images.githubusercontent.com/10138447/209980016-bf86d85b-9a61-4564-a6c5-2400f611466e.png">




## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure there are no errors on donor & donation detail pages who have not used next gen forms.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

