### PR TITLE
Refactor: Rename Form Builder menu title, page title, page slug

### DIFF
--- a/src/FormBuilder/FormBuilderRouteBuilder.php
+++ b/src/FormBuilder/FormBuilderRouteBuilder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Give\FormBuilder;
+
+class FormBuilderRouteBuilder
+{
+    const SLUG = 'form-builder-next-gen';
+
+    /**
+     * @var int|string
+     */
+    protected $donationFormID;
+
+    /**
+     * @unreleased
+     *
+     * @param int|string $donationFormID
+     */
+    protected function __construct($donationFormID)
+    {
+        $this->donationFormID = $donationFormID;
+    }
+
+    public static function makeCreateFormRoute(): self
+    {
+        // @todo Refactor create route so as not to mix types for $donationFormID.
+        return new self('new');
+    }
+
+    public static function makeEditFormRoute(int $donationFormID): self
+    {
+        return new self($donationFormID);
+    }
+
+    public function __toString()
+    {
+        return $this->getUrl();
+    }
+
+    public function getUrl(): string
+    {
+        return add_query_arg(
+            [
+                'post_type' => 'give_forms',
+                'page' => self::SLUG,
+                'donationFormID' => $this->donationFormID,
+            ],
+            admin_url('edit.php')
+        );
+    }
+}

--- a/src/FormBuilder/Routes/CreateFormRoute.php
+++ b/src/FormBuilder/Routes/CreateFormRoute.php
@@ -3,6 +3,7 @@
 namespace Give\FormBuilder\Routes;
 
 use Exception;
+use Give\FormBuilder\FormBuilderRouteBuilder;
 use Give\NextGen\DonationForm\Models\DonationForm;
 use Give\NextGen\DonationForm\Properties\FormSettings;
 use Give\NextGen\DonationForm\ValueObjects\DonationFormStatus;
@@ -22,10 +23,10 @@ class CreateFormRoute
      */
     public function __invoke()
     {
-        if (isset($_GET['page']) && 'campaign-builder' === $_GET['page']) {
+        if (isset($_GET['page']) && FormBuilderRouteBuilder::SLUG === $_GET['page']) {
             // Little hack for alpha users to make sure the form builder is loaded.
             if (!isset($_GET['donationFormID'])) {
-                wp_redirect('edit.php?post_type=give_forms&page=campaign-builder&donationFormID=new');
+                wp_redirect(FormBuilderRouteBuilder::makeCreateFormRoute());
                 exit();
             }
             if ('new' === $_GET['donationFormID']) {
@@ -52,7 +53,7 @@ class CreateFormRoute
                     'blocks' => BlockCollection::fromJson($blocksJson)
                 ]);
 
-                wp_redirect('edit.php?post_type=give_forms&page=campaign-builder&donationFormID=' . $form->id);
+                wp_redirect(FormBuilderRouteBuilder::makeEditFormRoute($form->id));
                 exit();
             }
         }

--- a/src/FormBuilder/Routes/EditFormRoute.php
+++ b/src/FormBuilder/Routes/EditFormRoute.php
@@ -2,6 +2,8 @@
 
 namespace Give\FormBuilder\Routes;
 
+use Give\FormBuilder\FormBuilderRouteBuilder;
+
 /**
  * Route to edit an existing form
  */
@@ -17,7 +19,7 @@ class EditFormRoute
         if (isset($_GET['post'], $_GET['action']) && 'edit' === $_GET['action']) {
             $post = get_post(abs($_GET['post']));
             if ('give_forms' === $post->post_type && $post->post_content) {
-                wp_redirect('edit.php?post_type=give_forms&page=campaign-builder&donationFormID=' . $post->ID);
+                wp_redirect(FormBuilderRouteBuilder::makeEditFormRoute($post->ID));
                 exit();
             }
         }

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -21,7 +21,7 @@ class RegisterFormBuilderPageRoute
     public function __invoke()
     {
         $pageTitle = __('Visual Donation Form Builder', 'givewp');
-        $menuTitle = __('Add Form', 'givewp');
+        $menuTitle = __('Add Next Gen Form', 'givewp');
         $version = __('Beta', 'givewp');
 
         add_submenu_page(

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -2,6 +2,7 @@
 
 namespace Give\FormBuilder\Routes;
 use Give\Addon\View;
+use Give\FormBuilder\FormBuilderRouteBuilder;
 use Give\FormBuilder\ViewModels\FormBuilderViewModel;
 use Give\Framework\EnqueueScript;
 
@@ -19,12 +20,16 @@ class RegisterFormBuilderPageRoute
      */
     public function __invoke()
     {
+        $pageTitle = __('Visual Donation Form Builder', 'givewp');
+        $menuTitle = __('Add Form', 'givewp');
+        $version = __('Beta', 'givewp');
+
         add_submenu_page(
             'edit.php?post_type=give_forms',
-            __('Visual Builder <span class="awaiting-mod">Alpha</span>', 'givewp'),
-            __('Visual Builder <span class="awaiting-mod">Alpha</span>', 'givewp'),
+            "$pageTitle&nbsp;<span class='awaiting-mod'>$version</span>",
+            "$menuTitle&nbsp;<span class='awaiting-mod'>$version</span>",
             'manage_options',
-            'campaign-builder',
+            FormBuilderRouteBuilder::SLUG,
             [$this, 'renderPage'],
             1
         );


### PR DESCRIPTION
> "Visual Builder" in admin menu is changed to "Add Form" with beta badge

https://app.asana.com/0/1203495935004514/1203495935004520/f

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the menu title for adding a new form (beta) as well as the related page title and page slug.

- Menu Title is now `Add Next Gen Form (Beta)`.
- Page Title is now `Visual Donation Form Builder` (without the per-release version).
- Page/Menu/Route Slug is now `form-builder-next-gen`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Hard coded relative URLs have been replaced with a URL Builder class.

`'edit.php?post_type=give_forms&page=campaign-builder&donationFormID=' . $post->ID`
is now
`FormBuilderRouteBuilder::makeEditFormRoute($post->ID)`

## Visuals

![image](https://user-images.githubusercontent.com/10858303/210401254-ccd0bcd1-d17f-422b-9c9e-ec150a483576.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

The only visible change should be the menu title. Otherwise, creating a new form and editing an existing form should have the same behavior.