### PR TITLE
Fix: Store backwards compatible form meta

### DIFF
--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -31,6 +31,7 @@ class StoreBackwardsCompatibleFormMeta
             ];
         }, $donationLevels, array_keys($donationLevels));
 
+        give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::PRICE_OPTION, 'multi');
         give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS, $donationLevels);
     }
 

--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -15,7 +15,13 @@ class StoreBackwardsCompatibleFormMeta
 
     public function storeDonationLevels(DonationForm $donationForm)
     {
-        $donationLevels = $donationForm->schema()->getNodeByName('amount')->getLevels();
+        $amountField = $donationForm->schema()->getNodeByName('amount');
+
+        if( ! $amountField ) {
+            return;
+        }
+
+        $donationLevels = $amountField->getLevels();
         $donationLevels = array_map(function ($donationLevel, $index) {
             return [
                 '_give_id' => [

--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -31,7 +31,7 @@ class StoreBackwardsCompatibleFormMeta
             ];
         }, $donationLevels, array_keys($donationLevels));
 
-        give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::PRICE_OPTION, 'multi');
+        give()->form_meta->update_meta($donationForm->id, '_give_price_option', 'multi'); // @todo: Replace with DonationFormMetaKeys::PRICE_OPTION
         give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS, $donationLevels);
     }
 

--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -7,7 +7,7 @@ use Give\NextGen\DonationForm\Models\DonationForm;
 
 class StoreBackwardsCompatibleFormMeta
 {
-    protected function storeDonationLevels(DonationForm $donationForm)
+    public function storeDonationLevels(DonationForm $donationForm)
     {
         $donationLevels = $donationForm->schema()->getNodeByName('amount')->getLevels();
         $donationLevels = array_map(function ($donationLevel, $index) {
@@ -22,7 +22,7 @@ class StoreBackwardsCompatibleFormMeta
         give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS, $donationLevels);
     }
 
-    protected function storeDonationGoal(DonationForm $donationForm)
+    public function storeDonationGoal(DonationForm $donationForm)
     {
         give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION, $donationForm->settings->enableDonationGoal ? 'enabled' : 'disabled');
 

--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -31,17 +31,18 @@ class StoreBackwardsCompatibleFormMeta
             ];
         }, $donationLevels, array_keys($donationLevels));
 
-        give()->form_meta->update_meta($donationForm->id, '_give_price_option', 'multi'); // @todo: Replace with DonationFormMetaKeys::PRICE_OPTION
-        give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS, $donationLevels);
+        // @todo: Replace with DonationFormMetaKeys::PRICE_OPTION when available.
+        $this->saveSingleFormMeta($donationForm->id, '_give_price_option', 'multi');
+        $this->saveSingleFormMeta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS, $donationLevels);
     }
 
     public function storeDonationGoal(DonationForm $donationForm)
     {
-        give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION, $donationForm->settings->enableDonationGoal ? 'enabled' : 'disabled');
+        $this->saveSingleFormMeta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION, $donationForm->settings->enableDonationGoal ? 'enabled' : 'disabled');
 
         $goalType = $donationForm->settings->goalType->getValue();
         $goalType = ($goalType === 'donations') ? 'donation' : $goalType; // @todo Mismatch. Legacy uses "donation" instead of "donations".
-        give()->form_meta->update_meta($donationForm->id, '_give_goal_format', $goalType);
+        $this->saveSingleFormMeta($donationForm->id, '_give_goal_format', $goalType);
 
         $metaLookup = [
             'donation' => '_give_number_of_donation_goal',
@@ -50,10 +51,15 @@ class StoreBackwardsCompatibleFormMeta
         ];
 
         $goalAmount = ('amount' === $goalType) ? give_sanitize_amount_for_db($donationForm->settings->goalAmount) : $donationForm->settings->goalAmount;
-        if( give()->form_meta->get_meta($donationForm->id, $metaLookup[$goalType], true)) {
-            give()->form_meta->update_meta($donationForm->id, $metaLookup[$goalType], $goalAmount);
+        $this->saveSingleFormMeta($donationForm->id, $metaLookup[$goalType], $goalAmount);
+    }
+
+    protected function saveSingleFormMeta($formId, $metaKey, $metaValue)
+    {
+        if( give()->form_meta->get_meta($formId, $metaKey, true)) {
+            give()->form_meta->update_meta($formId, $metaKey, $metaValue);
         } else {
-            give()->form_meta->add_meta($donationForm->id, $metaLookup[$goalType], $goalAmount);
+            give()->form_meta->add_meta($formId, $metaKey, $metaValue);
         }
     }
 }

--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -7,6 +7,12 @@ use Give\NextGen\DonationForm\Models\DonationForm;
 
 class StoreBackwardsCompatibleFormMeta
 {
+    public function __invoke(DonationForm $donationForm)
+    {
+        $this->storeDonationLevels($donationForm);
+        $this->storeDonationGoal($donationForm);
+    }
+
     public function storeDonationLevels(DonationForm $donationForm)
     {
         $donationLevels = $donationForm->schema()->getNodeByName('amount')->getLevels();

--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Give\NextGen\DonationForm\Actions;
+
+use Give\DonationForms\ValueObjects\DonationFormMetaKeys;
+use Give\NextGen\DonationForm\Models\DonationForm;
+
+class StoreBackwardsCompatibleFormMeta
+{
+    protected function storeDonationLevels(DonationForm $donationForm)
+    {
+        $donationLevels = $donationForm->schema()->getNodeByName('amount')->getLevels();
+        $donationLevels = array_map(function ($donationLevel, $index) {
+            return [
+                '_give_id' => [
+                    'level_id' => $index,
+                ],
+                '_give_amount' => $donationLevel
+            ];
+        }, $donationLevels, array_keys($donationLevels));
+
+        give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS, $donationLevels);
+    }
+
+    protected function storeDonationGoal(DonationForm $donationForm)
+    {
+        give()->form_meta->update_meta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION, $donationForm->settings->enableDonationGoal ? 'enabled' : 'disabled');
+
+        $goalType = $donationForm->settings->goalType->getValue();
+        $goalType = ($goalType === 'donations') ? 'donation' : $goalType; // @todo Mismatch. Legacy uses "donation" instead of "donations".
+        give()->form_meta->update_meta($donationForm->id, '_give_goal_format', $goalType);
+
+        $metaLookup = [
+            'donation' => '_give_number_of_donation_goal',
+            'donors' => '_give_number_of_donor_goal',
+            'amount' => '_give_set_goal',
+        ];
+
+        $goalAmount = ('amount' === $goalType) ? give_sanitize_amount_for_db($donationForm->settings->goalAmount) : $donationForm->settings->goalAmount;
+        if( give()->form_meta->get_meta($donationForm->id, $metaLookup[$goalType], true)) {
+            give()->form_meta->update_meta($donationForm->id, $metaLookup[$goalType], $goalAmount);
+        } else {
+            give()->form_meta->add_meta($donationForm->id, $metaLookup[$goalType], $goalAmount);
+        }
+    }
+}

--- a/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
+++ b/src/NextGen/DonationForm/Actions/StoreBackwardsCompatibleFormMeta.php
@@ -7,17 +7,23 @@ use Give\NextGen\DonationForm\Models\DonationForm;
 
 class StoreBackwardsCompatibleFormMeta
 {
+    /**
+     * @unreleased
+     */
     public function __invoke(DonationForm $donationForm)
     {
         $this->storeDonationLevels($donationForm);
         $this->storeDonationGoal($donationForm);
     }
 
+    /**
+     * @unreleased
+     */
     public function storeDonationLevels(DonationForm $donationForm)
     {
         $amountField = $donationForm->schema()->getNodeByName('amount');
 
-        if( ! $amountField ) {
+        if (!$amountField) {
             return;
         }
 
@@ -36,9 +42,16 @@ class StoreBackwardsCompatibleFormMeta
         $this->saveSingleFormMeta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS, $donationLevels);
     }
 
+    /**
+     * @unreleased
+     */
     public function storeDonationGoal(DonationForm $donationForm)
     {
-        $this->saveSingleFormMeta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION, $donationForm->settings->enableDonationGoal ? 'enabled' : 'disabled');
+        $this->saveSingleFormMeta(
+            $donationForm->id,
+            DonationFormMetaKeys::GOAL_OPTION,
+            $donationForm->settings->enableDonationGoal ? 'enabled' : 'disabled'
+        );
 
         $goalType = $donationForm->settings->goalType->getValue();
         $goalType = ($goalType === 'donations') ? 'donation' : $goalType; // @todo Mismatch. Legacy uses "donation" instead of "donations".
@@ -50,13 +63,18 @@ class StoreBackwardsCompatibleFormMeta
             'amount' => '_give_set_goal',
         ];
 
-        $goalAmount = ('amount' === $goalType) ? give_sanitize_amount_for_db($donationForm->settings->goalAmount) : $donationForm->settings->goalAmount;
+        $goalAmount = ('amount' === $goalType) ? give_sanitize_amount_for_db(
+            $donationForm->settings->goalAmount
+        ) : $donationForm->settings->goalAmount;
         $this->saveSingleFormMeta($donationForm->id, $metaLookup[$goalType], $goalAmount);
     }
 
+    /**
+     * @unreleased
+     */
     protected function saveSingleFormMeta($formId, $metaKey, $metaValue)
     {
-        if( give()->form_meta->get_meta($formId, $metaKey, true)) {
+        if (give()->form_meta->get_meta($formId, $metaKey, true)) {
             give()->form_meta->update_meta($formId, $metaKey, $metaValue);
         } else {
             give()->form_meta->add_meta($formId, $metaKey, $metaValue);

--- a/src/NextGen/DonationForm/ServiceProvider.php
+++ b/src/NextGen/DonationForm/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Give\NextGen\DonationForm;
 
 use Give\Helpers\Hooks;
+use Give\NextGen\DonationForm\Actions\StoreBackwardsCompatibleFormMeta;
 use Give\NextGen\DonationForm\Blocks\DonationFormBlock\Block as DonationFormBlock;
 use Give\NextGen\DonationForm\Routes\DonateRoute;
 use Give\NextGen\DonationForm\Routes\DonationFormPreviewRoute;
@@ -31,5 +32,8 @@ class ServiceProvider implements ServiceProviderInterface {
         Hooks::addAction('template_redirect', DonateRoute::class);
         Hooks::addAction('template_redirect', DonationFormViewRoute::class);
         Hooks::addAction('template_redirect', DonationFormPreviewRoute::class);
+
+        Hooks::addAction('givewp_donation_form_created', StoreBackwardsCompatibleFormMeta::class, 'storeDonationLevels');
+        Hooks::addAction('givewp_donation_form_updated', StoreBackwardsCompatibleFormMeta::class, 'storeDonationGoal');
     }
 }

--- a/src/NextGen/DonationForm/ServiceProvider.php
+++ b/src/NextGen/DonationForm/ServiceProvider.php
@@ -33,7 +33,7 @@ class ServiceProvider implements ServiceProviderInterface {
         Hooks::addAction('template_redirect', DonationFormViewRoute::class);
         Hooks::addAction('template_redirect', DonationFormPreviewRoute::class);
 
-        Hooks::addAction('givewp_donation_form_created', StoreBackwardsCompatibleFormMeta::class, 'storeDonationLevels');
-        Hooks::addAction('givewp_donation_form_updated', StoreBackwardsCompatibleFormMeta::class, 'storeDonationGoal');
+        Hooks::addAction('givewp_donation_form_created', StoreBackwardsCompatibleFormMeta::class);
+        Hooks::addAction('givewp_donation_form_updated', StoreBackwardsCompatibleFormMeta::class);
     }
 }

--- a/tests/Unit/DonationForm/Actions/StoreBackwardsCompatibleFormMetaTest.php
+++ b/tests/Unit/DonationForm/Actions/StoreBackwardsCompatibleFormMetaTest.php
@@ -78,6 +78,45 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
         $this->assertSame('500.000000', $this->getSingleFormMeta($donationForm->id, '_give_set_goal' ));
     }
 
+    /**
+     * @unreleased
+     */
+    public function testDonationGoalMetaUsesGoalTypeMetaKeyAmount()
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->make();
+        $donationForm->settings->goalType = GoalType::AMOUNT();
+        $donationForm->save();
+
+        $this->assertNotNull($this->getSingleFormMeta($donationForm->id, '_give_set_goal' ));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDonationGoalMetaUsesGoalTypeMetaKeyDonations()
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->make();
+        $donationForm->settings->goalType = GoalType::DONATIONS();
+        $donationForm->save();
+
+        $this->assertNotNull($this->getSingleFormMeta($donationForm->id, '_give_number_of_donation_goal' ));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDonationGoalMetaUsesGoalTypeMetaKeyDonors()
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->make();
+        $donationForm->settings->goalType = GoalType::DONORS();
+        $donationForm->save();
+
+        $this->assertNotNull($this->getSingleFormMeta($donationForm->id, '_give_number_of_donor_goal' ));
+    }
+
     protected function getSingleFormMeta($formId, $metaKey)
     {
         return give()->form_meta->get_meta($formId, $metaKey, $single = true);

--- a/tests/Unit/DonationForm/Actions/StoreBackwardsCompatibleFormMetaTest.php
+++ b/tests/Unit/DonationForm/Actions/StoreBackwardsCompatibleFormMetaTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Give\Tests\Unit\DonationForm\Actions;
+
+use Give\DonationForms\ValueObjects\DonationFormMetaKeys;
+use Give\NextGen\DonationForm\Models\DonationForm;
+use Give\NextGen\DonationForm\ValueObjects\GoalType;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+class StoreBackwardsCompatibleFormMetaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    public function testDonationLevelMetaIsStoredOnInsert()
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->create();
+
+        $this->assertEquals('multi', $this->getSingleFormMeta($donationForm->id, '_give_price_option' ));
+        $this->assertIsArray($this->getSingleFormMeta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDonationLevelMetaIsStoredOnUpdate()
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->create();
+        give()->form_meta->delete_meta($donationForm->id, '_give_price_option');
+        give()->form_meta->delete_meta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS);
+
+        $donationForm->save(); // Trigger update.
+
+        $this->assertEquals('multi', $this->getSingleFormMeta($donationForm->id, '_give_price_option' ));
+        $this->assertIsArray($this->getSingleFormMeta($donationForm->id, DonationFormMetaKeys::DONATION_LEVELS));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDonationGoalMetaIsStoredOnInsert()
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->make();
+        $donationForm->settings->enableDonationGoal = true;
+        $donationForm->settings->goalType = GoalType::AMOUNT();
+        $donationForm->settings->goalAmount = 500;
+        $donationForm->save(); // Trigger created hook.
+
+        $this->assertEquals('enabled', $this->getSingleFormMeta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION ));
+        $this->assertEquals('amount', $this->getSingleFormMeta($donationForm->id, '_give_goal_format' ));
+        $this->assertSame('500.000000', $this->getSingleFormMeta($donationForm->id, '_give_set_goal' ));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDonationGoalMetaIsStoredOnUpdate()
+    {
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->create();
+        give()->form_meta->delete_meta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION);
+        give()->form_meta->delete_meta($donationForm->id, '_give_goal_format');
+        give()->form_meta->delete_meta($donationForm->id, '_give_set_goal');
+
+        $donationForm->settings->enableDonationGoal = true;
+        $donationForm->settings->goalType = GoalType::AMOUNT();
+        $donationForm->settings->goalAmount = 500;
+        $donationForm->save(); // Trigger update hook.
+
+        $this->assertEquals('enabled', $this->getSingleFormMeta($donationForm->id, DonationFormMetaKeys::GOAL_OPTION ));
+        $this->assertEquals('amount', $this->getSingleFormMeta($donationForm->id, '_give_goal_format' ));
+        $this->assertSame('500.000000', $this->getSingleFormMeta($donationForm->id, '_give_set_goal' ));
+    }
+
+    protected function getSingleFormMeta($formId, $metaKey)
+    {
+        return give()->form_meta->get_meta($formId, $metaKey, $single = true);
+    }
+}


### PR DESCRIPTION
> Next Gen forms are fully compatible with new Form list table

https://app.asana.com/0/1203495935004514/1203495935004522/f

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR stores backwards compatible form meta for:
- Price Options (`multi`) <sup>1,2</sup>
- Donation Levels
- Donation Goal (enabled)
- Donation Goal Format
- Donation Goal Amount

<sup>1</sup> This will be updated to support the Set Donation price option when that is added to the form builder.
<sup>2</sup> The meta key is temporarily hard-coded and should be replaced after https://github.com/impress-org/givewp/pull/6614 is merged.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![Screenshot 2023-01-04 at 14-56-28 Donation Forms ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/210639657-5b9cc1db-51ba-46d6-b9f1-c44a106b5c43.png)
![Screenshot 2023-01-04 at 14-47-27 Donation Forms ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/210639659-e3caf2d8-3c02-4b84-9b09-978bc6b5931e.png)
![Screenshot 2023-01-04 at 14-45-15 Donation Forms ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/210639660-12b87c40-fa77-4ad8-9983-80db08eb2ca5.png)
![Screenshot 2023-01-04 at 14-44-56 Donation Forms ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/210639662-006822ed-e9b2-40ea-9052-f0a568fcd428.png)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Update the donation levels and donation goal form settings.


