### PR TITLE
Refactor: Move fields blocks to form meta

### DIFF
--- a/src/NextGen/DonationForm/Actions/ConvertQueryDataToDonationForm.php
+++ b/src/NextGen/DonationForm/Actions/ConvertQueryDataToDonationForm.php
@@ -25,7 +25,7 @@ class ConvertQueryDataToDonationForm
             'updatedAt' => Temporal::toDateTime($queryObject->updatedAt),
             'status' => new DonationFormStatus($queryObject->status),
             'settings' => FormSettings::fromjson($queryObject->{DonationFormMetaKeys::SETTINGS()->getKeyAsCamelCase()}),
-            'blocks' => BlockCollection::fromJson($queryObject->blocks)
+            'blocks' => BlockCollection::fromJson($queryObject->{DonationFormMetaKeys::FIELDS()->getKeyAsCamelCase()}),
         ]);
     }
 }

--- a/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
+++ b/src/NextGen/DonationForm/Repositories/DonationFormRepository.php
@@ -94,7 +94,7 @@ class DonationFormRepository
                     'post_type' => 'give_forms',
                     'post_parent' => 0,
                     'post_title' => $donationForm->title,
-                    'post_content' => $donationForm->blocks->toJson(),
+                    'post_content' => (new BlockCollection([]))->toJson(), // @todo Repurpose as form page.
                 ]);
 
             $donationFormId = DB::last_insert_id();
@@ -104,6 +104,13 @@ class DonationFormRepository
                     'form_id' => $donationFormId,
                     'meta_key' => DonationFormMetaKeys::SETTINGS()->getValue(),
                     'meta_value' => $donationForm->settings->toJson()
+                ]);
+
+            DB::table('give_formmeta')
+                ->insert([
+                    'form_id' => $donationFormId,
+                    'meta_key' => DonationFormMetaKeys::FIELDS()->getValue(),
+                    'meta_value' => $donationForm->blocks->toJson()
                 ]);
         } catch (Exception $exception) {
             DB::query('ROLLBACK');
@@ -152,7 +159,7 @@ class DonationFormRepository
                     'post_modified_gmt' => get_gmt_from_date($date),
                     'post_status' => $donationForm->status->getValue(),
                     'post_title' => $donationForm->title,
-                    'post_content' => $donationForm->blocks->toJson(),
+                    'post_content' => (new BlockCollection([]))->toJson(), // @todo Repurpose as form page.
                 ]);
 
             DB::table('give_formmeta')
@@ -160,6 +167,14 @@ class DonationFormRepository
                 ->where('meta_key', DonationFormMetaKeys::SETTINGS()->getValue())
                 ->update([
                     'meta_value' => $donationForm->settings->toJson()
+                ]);
+
+
+            DB::table('give_formmeta')
+                ->where('form_id', $donationForm->id)
+                ->where('meta_key', DonationFormMetaKeys::FIELDS()->getValue())
+                ->update([
+                    'meta_value' => $donationForm->blocks->toJson()
                 ]);
         } catch (Exception $exception) {
             DB::query('ROLLBACK');
@@ -240,7 +255,7 @@ class DonationFormRepository
                 ['post_modified', 'updatedAt'],
                 ['post_status', 'status'],
                 ['post_title', 'title'],
-                ['post_content', 'blocks']
+                ['post_content', 'page_content'] // @todo Repurpose as form page.
             )
             ->attachMeta(
                 'give_formmeta',

--- a/src/NextGen/DonationForm/ValueObjects/DonationFormMetaKeys.php
+++ b/src/NextGen/DonationForm/ValueObjects/DonationFormMetaKeys.php
@@ -9,11 +9,15 @@ use Give\Framework\Support\ValueObjects\EnumInteractsWithQueryBuilder;
  * @unreleased
  *
  * @method static DonationFormMetaKeys SETTINGS()
+ * @method static DonationFormMetaKeys FIELDS()
  * @method bool isSettings()
+ * @method bool isFields()
  */
 class DonationFormMetaKeys extends Enum
 {
     use EnumInteractsWithQueryBuilder;
 
     const SETTINGS = 'formBuilderSettings';
+
+    const FIELDS = 'formBuilderFields';
 }

--- a/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
+++ b/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
@@ -41,7 +41,7 @@ class ConvertQueryDataToDonationFormTest extends TestCase {
                 'registration' => 'none',
                 'goalType' => GoalType::AMOUNT()->getValue(),
             ]),
-            'blocks' =>  $blockCollection->toJson()
+            'fields' =>  $blockCollection->toJson()
         ];
 
         $donationForm = (new ConvertQueryDataToDonationForm())($queryData);

--- a/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
+++ b/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
@@ -41,7 +41,7 @@ class ConvertQueryDataToDonationFormTest extends TestCase {
                 'registration' => 'none',
                 'goalType' => GoalType::AMOUNT()->getValue(),
             ]),
-            'fields' =>  $blockCollection->toJson()
+            'blocks' =>  $blockCollection->toJson()
         ];
 
         $donationForm = (new ConvertQueryDataToDonationForm())($queryData);
@@ -58,7 +58,7 @@ class ConvertQueryDataToDonationFormTest extends TestCase {
                 'registration' => 'none',
                 'goalType' => GoalType::AMOUNT(),
             ]),
-            'fields' => $blockCollection
+            'blocks' => $blockCollection
         ]);
 
         $this->assertEquals($mockDonationForm->getAttributes(), $donationForm->getAttributes());

--- a/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
+++ b/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
@@ -41,7 +41,7 @@ class ConvertQueryDataToDonationFormTest extends TestCase {
                 'registration' => 'none',
                 'goalType' => GoalType::AMOUNT()->getValue(),
             ]),
-            'blocks' =>  $blockCollection->toJson()
+            'fields' =>  $blockCollection->toJson()
         ];
 
         $donationForm = (new ConvertQueryDataToDonationForm())($queryData);
@@ -58,7 +58,7 @@ class ConvertQueryDataToDonationFormTest extends TestCase {
                 'registration' => 'none',
                 'goalType' => GoalType::AMOUNT(),
             ]),
-            'blocks' => $blockCollection
+            'fields' => $blockCollection
         ]);
 
         $this->assertEquals($mockDonationForm->getAttributes(), $donationForm->getAttributes());

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -32,7 +32,7 @@ class FormBuilderViewModelTest extends TestCase
                 'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $formId),
                 'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($formId),
                 'nonce' => wp_create_nonce('wp_rest'),
-                'blockData' => get_post($formId)->post_content,
+                'blockData' => get_post_meta($formId, 'formBuilderFields', true),
                 'settings' => get_post_meta($formId, 'formBuilderSettings', true),
                 'currency' => give_get_currency(),
             ],


### PR DESCRIPTION
> Form Builder JSON is stored in meta

https://app.asana.com/0/1203461259668711/1203484321897874/f

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR moves the fields blocks JSON to form meta (out of post content<sup>1</sup>).

<sup>1</sup> The `post_content` now stores an empty JSON object as a placeholder. This is important for identifying a form as "Next Gen", which is used in the Next Gen Form Block and when editing a form.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Adds `\Give\NextGen\DonationForm\ValueObjects\DonationFormMetaKeys::FIELDS`.
- Updates `\Give\NextGen\DonationForm\Actions\ConvertQueryDataToDonationForm::__invoke`
- Updates `\Give\NextGen\DonationForm\Repositories\DonationFormRepository::insert`
- Updates `\Give\NextGen\DonationForm\Repositories\DonationFormRepository::update`
- Updates `\Give\NextGen\DonationForm\Repositories\DonationFormRepository::prepareQuery`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

 Create and update a Next Gen form.

- The blocks should be stored as meta (`formBuilderFields`).
- The `post_content` should have an empty JSON object (`[]`).

