### PR TITLE
Refactor: update default field settings, enqueue global form styles, and update form settings tab

### DIFF
--- a/packages/form-builder/src/blocks/fields/field.js
+++ b/packages/form-builder/src/blocks/fields/field.js
@@ -115,6 +115,11 @@ const field = {
                 source: 'attribute',
                 default: true,
             },
+            displayInReceipt: {
+                type: 'boolean',
+                source: 'attribute',
+                default: true,
+            }
         },
         title: __('Text', 'custom-block-editor'),
         icon: () => (

--- a/packages/form-builder/src/components/sidebar/primary.js
+++ b/packages/form-builder/src/components/sidebar/primary.js
@@ -1,4 +1,4 @@
-import {createSlotFill, PanelBody} from '@wordpress/components';
+import {createSlotFill} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 
 import './styles.scss';
@@ -6,19 +6,17 @@ import './styles.scss';
 import TabPanel from './tab-panel';
 
 import {
+    CustomStyleSettings,
     DonationGoalSettings,
     FormDesignSettings,
     FormSummarySettings,
-    OfflineDonationsSettings,
-    CustomStyleSettings,
     ReceiptSettings,
 } from '../../settings/index.ts';
-import FormFields from '../../settings/form-fields';
 import {PopoutSlot} from './popout';
 import {useEffect} from 'react';
 import useSelectedBlocks from '../../hooks/useSelectedBlocks';
 import BlockCard from "@wordpress/block-editor/build/components/block-card";
-import { settings } from '@wordpress/icons';
+import {settings} from '@wordpress/icons';
 
 const {Slot: InspectorSlot, Fill: InspectorFill} = createSlotFill('StandAloneBlockEditorSidebarInspector');
 
@@ -30,14 +28,16 @@ const tabs = [
         content: () => (
             <>
                 <BlockCard
-                    icon={ settings }
+                    icon={settings}
                     title="Form Settings"
                     description="These settings affect how your form functions and is presented, as well as the form page."
                 />
-                <FormSummarySettings />
-                <DonationGoalSettings />
-                <OfflineDonationsSettings />
-                <FormFields />
+                <FormSummarySettings/>
+                <DonationGoalSettings/>
+                <ReceiptSettings/>
+                {/*The settings below have not been implemented yet.*/}
+                {/*<OfflineDonationsSettings/>*/}
+                {/*<FormFields />*/}
             </>
         ),
     },
@@ -59,7 +59,6 @@ const tabs = [
             <>
                 <FormDesignSettings />
                 <DonationGoalSettings />
-                <ReceiptSettings />
                 <CustomStyleSettings />
             </>
         )

--- a/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
+++ b/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
@@ -11,6 +11,9 @@ use Give\NextGen\DonationForm\ValueObjects\GoalType;
 use Give\NextGen\Framework\Blocks\BlockCollection;
 use Give\NextGen\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 
+use function wp_enqueue_style;
+use function wp_print_styles;
+
 /**
  * @unreleased
  */
@@ -25,9 +28,8 @@ class DonationFormViewModel
      */
     private $formBlocks;
     /**
-     * TODO: replace formSettings array with $donationForm->settings object when property gets updated
      *
-     * @var array{designId: string, primaryColor: string, secondaryColor: string, goalType: string}
+     * @var FormSettings
      */
     private $formSettings;
     /**
@@ -71,6 +73,29 @@ class DonationFormViewModel
     public function secondaryColor(): string
     {
         return $this->formSettings->secondaryColor ?? '';
+    }
+
+    /**
+     * @unreleased
+     */
+    public function enqueueGlobalStyles()
+    {
+        wp_enqueue_global_styles();
+        
+        wp_register_style(
+            'givewp-global-form-styles',
+            GIVE_NEXT_GEN_URL . 'src/NextGen/DonationForm/resources/styles/global.css'
+        );
+
+        wp_add_inline_style(
+            'givewp-global-form-styles',
+            ":root {
+            --givewp-primary-color:{$this->primaryColor()};
+            --givewp-secondary-color:{$this->secondaryColor()}; 
+            }"
+        );
+
+        wp_enqueue_style('givewp-global-form-styles');
     }
 
     /**
@@ -146,7 +171,7 @@ class DonationFormViewModel
      */
     public function render(): string
     {
-        wp_enqueue_global_styles();
+        $this->enqueueGlobalStyles();
 
         $this->enqueueFormScripts(
             $this->donationFormId,
@@ -162,18 +187,14 @@ class DonationFormViewModel
             window.giveNextGenExports = <?= wp_json_encode($this->exports()) ?>;
         </script>
 
-        <?php if($this->formSettings->customCss): ?>
-        <style><?php echo $this->formSettings->customCss; ?></style>
-        <?php endif; ?>
+        <?php
+        if ($this->formSettings->customCss): ?>
+            <style><?php
+                echo $this->formSettings->customCss; ?></style>
+        <?php
+        endif; ?>
 
-        <div
-            id="root-givewp-donation-form"
-            class="givewp-donation-form"
-            style="
-                --givewp-primary-color:<?= $this->primaryColor() ?>;
-                --givewp-secondary-color:<?= $this->secondaryColor() ?>;
-                "
-        ></div>
+        <div id="root-givewp-donation-form" class="givewp-donation-form"></div>
 
         <?php
         wp_print_footer_scripts();

--- a/src/NextGen/DonationForm/resources/styles/global.css
+++ b/src/NextGen/DonationForm/resources/styles/global.css
@@ -1,0 +1,7 @@
+/**
+* Next Gen Global Form Styles
+* @handle 'givewp-global-form-styles'
+* The main use for this file is to add dynamic css variables using wp_add_inline_style
+* @see https://developer.wordpress.org/reference/functions/wp_add_inline_style/
+* @unreleased
+*/


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->


## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Updates custom fields to have "Display in Receipt" checked by default.
- Enqueues a new global stylesheet so our custom css variables are elevated to the head tag, this will ensure proper cascading of our css variables downstream.
- Moves the receipt settings into the form settings tab
- Comments out unused form settings that are not implemented yet

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Custom field default settings
- Form rendering styles

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Default settings**

<img width="303" alt="Screenshot 2023-01-24 at 12 09 16 PM" src="https://user-images.githubusercontent.com/10138447/214360696-cd8a9709-7a94-4f48-8a9f-e0bf3f8dc37f.png">

**Form settings tab**

<img width="290" alt="Screenshot 2023-01-24 at 12 09 26 PM" src="https://user-images.githubusercontent.com/10138447/214360735-0e5a20e6-2c69-410c-9984-0aa741848ad7.png">

**Global styles in head tag**

<img width="530" alt="Screenshot 2023-01-24 at 12 09 48 PM" src="https://user-images.githubusercontent.com/10138447/214360773-6263b7b0-a3cd-4898-9671-d1651e2168e6.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- run `npm run build` and make sure form builder and form look okay.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

