### PR TITLE
Fix: Add back color setting defaults

### DIFF
--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -411,3 +411,7 @@ This creates a consistent separator between the tabs and the rest of the sidebar
         margin-bottom: 0;
     }
 }
+
+.popover-slot {
+    position: fixed;
+}

--- a/packages/form-builder/src/settings/design/index.tsx
+++ b/packages/form-builder/src/settings/design/index.tsx
@@ -4,6 +4,7 @@ import {__} from '@wordpress/i18n';
 import {setFormSettings, useFormState, useFormStateDispatch} from '../../stores/form-state';
 import {getWindowData} from '@givewp/form-builder/common';
 import debounce from 'lodash.debounce';
+import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
 
 const {formDesigns} = getWindowData();
 
@@ -64,12 +65,14 @@ const FormDesignSettings = () => {
                         onChange: debounce((primaryColor) => dispatch(setFormSettings({primaryColor})), 100),
                         label: __('Primary Color', 'give'),
                         disableCustomColors: false,
+                        colors: SETTINGS_DEFAULTS.colors,
                     },
                     {
                         value: secondaryColor,
                         onChange: debounce((secondaryColor) => dispatch(setFormSettings({secondaryColor})), 100),
                         label: __('Secondary Color', 'give'),
                         disableCustomColors: false,
+                        colors: SETTINGS_DEFAULTS.colors,
                     },
                 ]}
             />


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR restores the default color options in the color dropdown. The default values were removed by Gutenberg to be more dynamic.

Also, this affixes the color dropdown to the popover slot so that it does not scroll with the form.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/214389783-b0f00294-0fd1-4f4a-b140-7ea1acf21a0e.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Run `npm run build:form-builder` and check that the color settings in Design Mode have default options to choose from. Also, the color picker should not scroll with the form, but rather scroll with the sidebar.