### PR TITLE
Fix: Stripe gateway customer retrieval

### DIFF
--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
@@ -108,15 +108,12 @@ class NextGenStripeGateway extends PaymentGateway implements NextGenPaymentGatew
         /**
          * Get or create a Stripe customer
          */
-        $customer = $this->getOrCreateStripeCustomerFromDonation(
-            $stripeConnectedAccountKey,
-            $donation
-        );
+        $customerId = $this->legacyGetOrCreateStripeCustomer($donation);
 
         /**
          * Setup Stripe Payment Intent args
          */
-        $intentArgs = $this->getPaymentIntentArgsFromDonation($donation, $customer);
+        $intentArgs = $this->getPaymentIntentArgsFromDonation($donation, $customerId);
 
         /**
          * Update Payment Intent

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
@@ -108,12 +108,13 @@ class NextGenStripeGateway extends PaymentGateway implements NextGenPaymentGatew
         /**
          * Get or create a Stripe customer
          */
-        $customerId = $this->legacyGetOrCreateStripeCustomer($donation);
+        $customer = $this->getOrCreateStripeCustomerFromDonation($stripeConnectedAccountKey, $donation);
+
 
         /**
          * Setup Stripe Payment Intent args
          */
-        $intentArgs = $this->getPaymentIntentArgsFromDonation($donation, $customerId);
+        $intentArgs = $this->getPaymentIntentArgsFromDonation($donation, $customer);
 
         /**
          * Update Payment Intent

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
@@ -7,12 +7,12 @@ use Give\Donations\Models\DonationNote;
 use Give\Framework\Exceptions\Primitives\Exception;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Exceptions\InvalidPropertyName;
-use Give\PaymentGateways\Gateways\Stripe\Actions\GetOrCreateStripeCustomer;
 use Give\PaymentGateways\Gateways\Stripe\Actions\SaveDonationSummary;
-use Give\PaymentGateways\Gateways\Stripe\Exceptions\StripeCustomerException;
 use Give\PaymentGateways\Stripe\ApplicationFee;
 use Stripe\Customer;
+use Stripe\ErrorObject;
 use Stripe\Exception\ApiErrorException;
+use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
 
 trait NextGenStripeRepository {
@@ -42,34 +42,46 @@ trait NextGenStripeRepository {
     public function getOrCreateStripeCustomerFromDonation(
         string $connectAccountId,
         Donation $donation
-    ): Customer {
+    ): Customer
+    {
         $donorCustomerId = give_stripe_get_customer_id($donation->email) ?? '';
 
-        // make sure customerId still exists in  connect account
-        if ($donorCustomerId) {
-            $customer = Customer::retrieve($donorCustomerId, ['stripe_account' => $connectAccountId]);
+        // create a new customer if the donor does not have a stripe id
+        if (!$donorCustomerId) {
+            $customer = $this->createCustomer($donation, $connectAccountId);
+        } else {
+            try {
+                // if the donor has a stripe ID, try retrieving the customer from Stripe.
+                $customer = $this->retrieveCustomer($donorCustomerId, $connectAccountId);
+
+                // if the customer is deleted, create a new customer
+                if ($customer->isDeleted()) {
+                    $customer = $this->createCustomer($donation, $connectAccountId);
+                }
+            } catch (InvalidRequestException $e) {
+                // If the donor has a stripe id but is not valid with this account,
+                // a resource_missing error will be thrown. In this case, we need to
+                // create a new customer.  The newer Stripe api has a search functionality
+                // that would make more sense here.
+                if ($e->getStripeCode() === ErrorObject::CODE_RESOURCE_MISSING) {
+                    $customer = $this->createCustomer($donation, $connectAccountId);
+                }
+            }
         }
 
-        // create a new customer if necessary
-        if (!$donorCustomerId || !$customer) {
-            $customer = Customer::create(
-                [
-                    'name' => "$donation->firstName $donation->lastName",
-                    'email' => $donation->email,
-                ],
-                ['stripe_account' => $connectAccountId]
-            );
-        }
-
-         DonationNote::create([
+        DonationNote::create([
             'donationId' => $donation->id,
             'content' => sprintf(__('Stripe Customer ID: %s', 'give'), $customer->id)
         ]);
 
+
+        // save the stripe ID to donor meta
+        // it appears this does not account for multiple stripe accounts
         if ($customer->id !== $donorCustomerId) {
             give()->donor_meta->update_meta($donation->donorId, give_stripe_get_customer_key(), $customer->id);
         }
 
+        // also save to donation meta
         give_update_meta($donation->id, give_stripe_get_customer_key(), $customer->id);
 
         return $customer;
@@ -92,12 +104,12 @@ trait NextGenStripeRepository {
      *
      * @throws InvalidPropertyName
      */
-    protected function getPaymentIntentArgsFromDonation(Donation $donation, string $customerId): array
+    protected function getPaymentIntentArgsFromDonation(Donation $donation, Customer $customer): array
     {
         // Collect intent args to be updated
         $intentArgs = [
             'amount' => $donation->amount->formatToMinorAmount(),
-            'customer' => $customerId,
+            'customer' => $customer->id,
             'description' => (new SaveDonationSummary)($donation)->getSummaryWithDonor(),
             'metadata' => give_stripe_prepare_metadata($donation->id),
         ];
@@ -173,13 +185,24 @@ trait NextGenStripeRepository {
     }
 
     /**
-     * @unreleased
-     *
-     * @throws Exception
-     * @throws StripeCustomerException
+     * @throws ApiErrorException
      */
-    protected function legacyGetOrCreateStripeCustomer(Donation $donation): string
+    protected function createCustomer(Donation $donation, string $connectAccountId): Customer
     {
-        return (new GetOrCreateStripeCustomer())($donation)->get_id();
+        return Customer::create(
+            [
+                'name' => "$donation->firstName $donation->lastName",
+                'email' => $donation->email,
+            ],
+            ['stripe_account' => $connectAccountId]
+        );
+    }
+
+    /**
+     * @throws ApiErrorException
+     */
+    protected function retrieveCustomer(string $customerId, string $connectAccountId): Customer
+    {
+        return Customer::retrieve($customerId, ['stripe_account' => $connectAccountId]);
     }
 }

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
@@ -53,6 +53,11 @@ trait NextGenStripeRepository {
             try {
                 // if the donor has a stripe ID, try retrieving the customer from Stripe.
                 $customer = $this->retrieveCustomer($donorCustomerId, $connectAccountId);
+
+                // if the customer is deleted, create a new customer
+                if ($customer->isDeleted()) {
+                    $customer = $this->createCustomer($donation, $connectAccountId);
+                }
             } catch (InvalidRequestException $exception) {
                 // If the donor has a stripe id but is not valid with this account,
                 // a resource_missing error will be thrown. In this case, we need to
@@ -63,11 +68,6 @@ trait NextGenStripeRepository {
                 } else {
                     throw $exception;
                 }
-            }
-
-            // if the customer is deleted, create a new customer
-            if ($customer->isDeleted()) {
-                $customer = $this->createCustomer($donation, $connectAccountId);
             }
         }
 

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
@@ -53,19 +53,21 @@ trait NextGenStripeRepository {
             try {
                 // if the donor has a stripe ID, try retrieving the customer from Stripe.
                 $customer = $this->retrieveCustomer($donorCustomerId, $connectAccountId);
-
-                // if the customer is deleted, create a new customer
-                if ($customer->isDeleted()) {
-                    $customer = $this->createCustomer($donation, $connectAccountId);
-                }
-            } catch (InvalidRequestException $e) {
+            } catch (InvalidRequestException $exception) {
                 // If the donor has a stripe id but is not valid with this account,
                 // a resource_missing error will be thrown. In this case, we need to
                 // create a new customer.  The newer Stripe api has a search functionality
                 // that would make more sense here.
-                if ($e->getStripeCode() === ErrorObject::CODE_RESOURCE_MISSING) {
+                if ($exception->getStripeCode() === ErrorObject::CODE_RESOURCE_MISSING) {
                     $customer = $this->createCustomer($donation, $connectAccountId);
+                } else {
+                    throw $exception;
                 }
+            }
+
+            // if the customer is deleted, create a new customer
+            if ($customer->isDeleted()) {
+                $customer = $this->createCustomer($donation, $connectAccountId);
             }
         }
 

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
@@ -185,6 +185,8 @@ trait NextGenStripeRepository {
     }
 
     /**
+     * @unreleased
+     *
      * @throws ApiErrorException
      */
     protected function createCustomer(Donation $donation, string $connectAccountId): Customer
@@ -199,7 +201,9 @@ trait NextGenStripeRepository {
     }
 
     /**
-     * @throws ApiErrorException
+     * @unreleased
+     *
+     * @throws ApiErrorException|InvalidRequestException
      */
     protected function retrieveCustomer(string $customerId, string $connectAccountId): Customer
     {

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeRepository.php
@@ -44,7 +44,7 @@ trait NextGenStripeRepository {
         Donation $donation
     ): Customer
     {
-        $donorCustomerId = give_stripe_get_customer_id($donation->email) ?? '';
+        $donorCustomerId = give_stripe_get_customer_id($donation->email);
 
         // create a new customer if the donor does not have a stripe id
         if (!$donorCustomerId) {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes an issue with a donor making a donation through different stripe accounts.  In order to achieve this we needed to catch Stripe's `InvalidRequestException` exception when a customer is not found and then create a new customer.  This is actually how the logic works in legacy.  We also are checking if a customer has the is_deleted flag so we can re-create the customer.

**Note**
While this logic has been working for us for some time, I am seeing room for improvement.  

**Multiple Stipe account**
GiveWP has the ability to use different Stripe accounts.  From what I can tell, our donor meta does not account for this - meaning anytime a donor uses stripe for a donation, the customer ID for _that_ account is saved to their meta - overwriting the previous value.  We should really have an identifier for that customer ID that connects back to the specific stripe account it's for.  That could be something like a key / value pair with the stripe account as the key and customer ID as the value:

```
_give_stripe_customer_id{_test} = [
'acc_12345' => 'cus_12345',
'acc_54321' => 'cus_54321'
];
```

**Stripe API & searching**
Newer versions of the Stripe api feature a search functionality.  This would be a much better use case for us when try to retrieve a customer record.  As pointed out earlier, the only way to know if a customer _does not_ exist is by catching a _resource_missing_ exception.  Searching for a customer based on ID and/or email appears to be a more appropriate way of looking up a customer.

```
$stripe->customers->search(['query' => 'email:\'sally@rocketrides.io\'']);
```


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Next Gen Stripe gateway

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Donate with a Stripe account
- Now connect to a different Stripe account (set as default)
- Donate with the same email as before
- The donation should go through properly

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

