### PR TITLE
Refactor: simplify default receipt template tags

### DIFF
--- a/packages/form-builder/src/settings/receipt/index.tsx
+++ b/packages/form-builder/src/settings/receipt/index.tsx
@@ -3,6 +3,23 @@ import {createInterpolateElement} from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 
+const TemplateTags = () => (
+    <dl>
+        <dt>
+            <code>{'{first_name}'}</code>
+        </dt>
+        <dd>First name field</dd>
+        <dt>
+            <code>{'{last_name}'}</code>
+        </dt>
+        <dd>Last name field</dd>
+        <dt>
+            <code>{'{email}'}</code>
+        </dt>
+        <dd>Email field</dd>
+    </dl>
+);
+
 const ReceiptSettings = () => {
     const {
         settings: {receiptHeading, receiptDescription},
@@ -10,22 +27,16 @@ const ReceiptSettings = () => {
     const dispatch = useFormStateDispatch();
 
     const headingHelpText = createInterpolateElement(
-        __(
-            'This is the first message that displays in the receipt. Learn more about using template tags <a>here</a>',
-            'give'
-        ),
+        __('This is the first message that displays in the receipt. Available template tags are: <tags />', 'give'),
         {
-            a: <a href="https://givewp.com/documentation/" target="_blank" />,
+            tags: <TemplateTags />,
         }
     );
 
     const descriptionHelpText = createInterpolateElement(
-        __(
-            'This is the second message that displays in the receipt. Learn more about using template tags <a>here</a>',
-            'give'
-        ),
+        __('This is the second message that displays in the receipt.Available template tags are: <tags />', 'give'),
         {
-            a: <a href="https://givewp.com/documentation/" target="_blank" />,
+            tags: <TemplateTags />,
         }
     );
 

--- a/packages/form-builder/src/settings/receipt/index.tsx
+++ b/packages/form-builder/src/settings/receipt/index.tsx
@@ -8,15 +8,12 @@ const TemplateTags = () => (
         <dt>
             <code>{'{first_name}'}</code>
         </dt>
-        <dd>First name field</dd>
         <dt>
             <code>{'{last_name}'}</code>
         </dt>
-        <dd>Last name field</dd>
         <dt>
             <code>{'{email}'}</code>
         </dt>
-        <dd>Email field</dd>
     </dl>
 );
 

--- a/src/NextGen/DonationForm/Properties/FormSettings.php
+++ b/src/NextGen/DonationForm/Properties/FormSettings.php
@@ -115,11 +115,11 @@ class FormSettings implements Arrayable, Jsonable
             'give'
         );
         $self->receiptHeading = $array['receiptHeading'] ?? __(
-            'Hey {donor.firstName}, thanks for your donation!',
+            'Hey {first_name}, thanks for your donation!',
             'give'
         );
         $self->receiptDescription = $array['receiptDescription'] ?? __(
-            '{donor.firstName}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {donor.email}.',
+            '{first_name}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {email}.',
             'give'
         );
 

--- a/src/NextGen/Framework/TemplateTags/DonationTemplateTags.php
+++ b/src/NextGen/Framework/TemplateTags/DonationTemplateTags.php
@@ -37,10 +37,9 @@ class DonationTemplateTags {
     protected function getTags(): array
     {
         return [
-            '{donation.firstName}' => $this->donation->firstName,
-            '{donation.email}' => $this->donation->email,
-            '{donor.firstName}' => $this->donation->donor->firstName,
-            '{donor.email}' => $this->donation->donor->email,
+            '{first_name}' => $this->donation->firstName,
+            '{last_name}' => $this->donation->lastName,
+            '{email}' => $this->donation->email,
         ];
     }
 }

--- a/tests/Unit/Framework/TemplateTags/Actions/TestTransformTemplateTags.php
+++ b/tests/Unit/Framework/TemplateTags/Actions/TestTransformTemplateTags.php
@@ -12,10 +12,10 @@ class TestTransformTemplateTags extends TestCase {
      * @return void
      */
     public function testShouldTransformTemplateTags() {
-        $content = "{donation.firstName}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {donation.email}.";
+        $content = "{first_name}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {donation.email}.";
         $tags = [
-            '{donation.firstName}' => 'Bill',
-            '{donation.email}' => 'bill@murray.com'
+            '{first_name}' => 'Bill',
+            '{email}' => 'bill@murray.com'
         ];
 
         $transformedContent = (new TransformTemplateTags())($content, $tags);

--- a/tests/Unit/Framework/TemplateTags/Actions/TestTransformTemplateTags.php
+++ b/tests/Unit/Framework/TemplateTags/Actions/TestTransformTemplateTags.php
@@ -12,7 +12,7 @@ class TestTransformTemplateTags extends TestCase {
      * @return void
      */
     public function testShouldTransformTemplateTags() {
-        $content = "{first_name}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {donation.email}.";
+        $content = "{first_name}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {email}.";
         $tags = [
             '{first_name}' => 'Bill',
             '{email}' => 'bill@murray.com'

--- a/tests/Unit/Framework/TemplateTags/TestDonationTemplateTags.php
+++ b/tests/Unit/Framework/TemplateTags/TestDonationTemplateTags.php
@@ -20,7 +20,7 @@ class TestDonationTemplateTags extends TestCase {
             'email' => 'bill@murray.com'
         ]);
 
-        $content = "{donation.firstName}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {donation.email}.";
+        $content = "{first_name}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {email}.";
 
         $tags = new DonationTemplateTags($donation, $content);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This simplifies the default confirmation receipt template tags to `first_name`, `last_name`, and `email`. These all comes from the donation model so whatever was entered into these fields at the time of donating will be used.  Since this is technically an un-authenticated url - we don't want to expose any actual donor information.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The confirmation receipt & settings.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="284" alt="Screenshot 2023-03-27 at 4 09 27 PM" src="https://user-images.githubusercontent.com/10138447/228054996-b98ce286-cd12-46df-8637-2af840fc5e17.png">


<img width="829" alt="Screenshot 2023-03-27 at 4 06 31 PM" src="https://user-images.githubusercontent.com/10138447/228054389-a38ea259-ff9d-47cf-8bd2-e4c8151e04ce.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a next gen form (or modify the existing settings with these template tags)
- Make a donation and view the confirmation receipt

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

