### PR TITLE
Fix: Add fallback value for setPrice when fixed

### DIFF
--- a/packages/form-builder/src/blocks.json
+++ b/packages/form-builder/src/blocks.json
@@ -22,7 +22,7 @@
                         "500"
                     ],
                     "priceOption": "multi",
-                    "setPrice": "100",
+                    "setPrice": "25",
                     "customAmount": "true",
                     "customAmountMin": 1,
                     "lock": {

--- a/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -29,7 +29,7 @@ const Inspector = ({attributes, setAttributes}) => {
                     <CurrencyControl
                         label={__('Set Donation', 'give')}
                         value={setPrice}
-                        onBlur={() => setPrice || setAttributes({setPrice: 100})}
+                        onBlur={() => setPrice || setAttributes({setPrice: 25})}
                         onValueChange={(setPrice) => setAttributes({setPrice: setPrice ? parseInt(setPrice) : 0})}
                     />
                 )}

--- a/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -29,7 +29,8 @@ const Inspector = ({attributes, setAttributes}) => {
                     <CurrencyControl
                         label={__('Set Donation', 'give')}
                         value={setPrice}
-                        onValueChange={(setPrice) => setAttributes({setPrice})}
+                        onBlur={() => setPrice || setAttributes({setPrice: 100})}
+                        onValueChange={(setPrice) => setAttributes({setPrice: setPrice ? parseInt(setPrice) : 0})}
                     />
                 )}
             </PanelBody>

--- a/packages/form-builder/src/blocks/fields/amount/settings.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/settings.tsx
@@ -23,7 +23,7 @@ const settings: FieldBlock['settings'] = {
         },
         setPrice: {
             type: 'number',
-            default: '100',
+            default: '25',
         },
         customAmount: {
             type: 'boolean',


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR ensures a fallback value for the `setPrice` value when using a fixed donation.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![Peek 2023-03-28 09-19](https://user-images.githubusercontent.com/10858303/228250554-5e82c24c-9a72-4615-aa83-e5bb5bb81a64.gif)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Set the Donation Option to a Fixed Donation.
- Delete the value of the Set Donation setting.
- The Set Donation should fallback to `100`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203940464851369