### PR TITLE
Feature: add recurring support for PayPal Standard

### DIFF
--- a/src/NextGen/Gateways/PayPal/PayPalStandardGateway/Actions/CancelPayPalStandardSubscription.php
+++ b/src/NextGen/Gateways/PayPal/PayPalStandardGateway/Actions/CancelPayPalStandardSubscription.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Give\NextGen\Gateways\PayPal\PayPalStandardGateway\Actions;
+
+use Give\Framework\PaymentGateways\Exceptions\PaymentGatewayException;
+use Give\Framework\PaymentGateways\Log\PaymentGatewayLog;
+use Give\Subscriptions\Models\Subscription;
+
+class CancelPayPalStandardSubscription
+{
+    /**
+     * *PORTED OVER FROM GIVE-RECURRING (give-recurring-paypal.php)*
+     *
+     * Cancel PayPal Subscription.
+     *
+     * Performs an Express Checkout NVP API operation as passed in $api_method.
+     * Although the PayPal Standard API provides no facility for cancelling a subscription,
+     * the PayPal; Express Checkout NVP API can be used.
+     *
+     * @unreleased
+     * @throws PaymentGatewayException
+     */
+    public function __invoke(Subscription $subscription)
+    {
+        $credentials = $this->get_paypal_standard_api_credentials();
+
+        // validate credentials
+        foreach ($credentials as $cred => $value) {
+            if (empty($value)) {
+                PaymentGatewayLog::error(
+                    '[PayPal Standard]: There was a problem cancelling the subscription.',
+                    ['error' => "Missing credential from settings: $cred."]
+                );
+
+                throw new PaymentGatewayException(
+                    'There was a problem cancelling the subscription, please contact customer support.'
+                );
+            }
+        }
+
+        $username = $credentials['username'];
+        $password = $credentials['password'];
+        $signature = $credentials['signature'];
+
+        if (give_is_test_mode()) {
+            $api_endpoint = 'https://api-3t.sandbox.paypal.com/nvp';
+        } else {
+            $api_endpoint = 'https://api-3t.paypal.com/nvp';
+        }
+
+        $args = array(
+            'USER' => $username,
+            'PWD' => $password,
+            'SIGNATURE' => $signature,
+            'METHOD' => 'ManageRecurringPaymentsProfileStatus',
+            'PROFILEID' => $subscription->gatewaySubscriptionId,
+            'VERSION' => '124',
+            'ACTION' => 'Cancel',
+        );
+
+        $error_msg = '';
+        $request = wp_remote_post($api_endpoint, array(
+            'body' => $args,
+            'httpversion' => '1.1',
+            'timeout' => 30,
+        ));
+
+        if (is_wp_error($request)) {
+            $success = false;
+            $error_msg = $request->get_error_message();
+        } else {
+            $body = wp_remote_retrieve_body($request);
+
+            if (is_string($body)) {
+                wp_parse_str($body, $body);
+            }
+
+            if (empty($request['response'])) {
+                $success = false;
+            }
+
+            if (empty($request['response']['code']) || 200 !== (int)$request['response']['code']) {
+                $success = false;
+            }
+
+            if (empty($request['response']['message']) || 'OK' !== $request['response']['message']) {
+                $success = false;
+            }
+
+            if (isset($body['ACK']) && 'success' === strtolower($body['ACK'])) {
+                $success = true;
+            } elseif (isset($body['L_LONGMESSAGE0'])) {
+                $error_msg = $body['L_LONGMESSAGE0'];
+            }
+        }
+
+        if (empty($success)) {
+            PaymentGatewayLog::error(
+                '[PayPal Standard]: There was a problem cancelling the subscription.',
+                ['error' => $error_msg]
+            );
+
+            throw new PaymentGatewayException(
+                'There was a problem cancelling the subscription, please contact customer support.'
+            );
+        }
+    }
+
+    /**
+     *
+     * *PORTED OVER FROM GIVE-RECURRING (give-recurring-paypal.php)*
+     *
+     * Retrieve PayPal API credentials
+     *
+     * @access      public
+     * @since       1.0
+     *
+     * @return mixed
+     */
+    public function get_paypal_standard_api_credentials()
+    {
+        $prefix = 'live_';
+
+        if (give_is_test_mode()) {
+            $prefix = 'test_';
+        }
+
+        $creds = array(
+            'username' => give_get_option($prefix . 'paypal_standard_api_username'),
+            'password' => give_get_option($prefix . 'paypal_standard_api_password'),
+            'signature' => give_get_option($prefix . 'paypal_standard_api_signature'),
+        );
+
+        return apply_filters('give_recurring_get_paypal_standard_api_credentials', $creds);
+    }
+}

--- a/src/NextGen/Gateways/PayPal/PayPalStandardGateway/PayPalStandardGatewaySubscriptionModule.php
+++ b/src/NextGen/Gateways/PayPal/PayPalStandardGateway/PayPalStandardGatewaySubscriptionModule.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Give\NextGen\Gateways\PayPal\PayPalStandardGateway;
+
+use Give\Donations\Models\Donation;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionAmountEditable;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionDashboardLinkable;
+use Give\Framework\PaymentGateways\SubscriptionModule;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\ValueObjects\SubscriptionMode;
+
+/**
+ * @unreleased
+ */
+class PayPalStandardGatewaySubscriptionModule extends SubscriptionModule implements SubscriptionDashboardLinkable,
+                                                                                   SubscriptionAmountEditable
+{
+    /**
+     * @unreleased
+     */
+    public function createSubscription(
+        Donation $donation,
+        Subscription $subscription,
+        $gatewayData
+    ) {
+      // TODO: Implement createSubscription() method.
+    }
+
+    /**
+     * @unreleased
+     */
+    public function cancelSubscription(Subscription $subscription)
+    {
+        //TODO: Implement cancelSubscription() method.
+    }
+
+    /**
+     * @unreleased
+     */
+    public function updateSubscriptionAmount(Subscription $subscription, Money $newRenewalAmount)
+    {
+       //TODO: Implement updateSubscriptionAmount() method.
+    }
+
+    /**
+     * @unreleased
+     */
+    public function gatewayDashboardSubscriptionUrl(Subscription $subscription): string
+    {
+        //TODO: Implement gatewayDashboardSubscriptionUrl() method.
+        
+        $url = $subscription->mode->equals(SubscriptionMode::LIVE()) ?
+            'https://test.com/' :
+            'https://live/';
+
+        return esc_url("{$url}subscriptions/$subscription->gatewaySubscriptionId");
+    }
+}

--- a/src/NextGen/Gateways/PayPal/PayPalStandardGateway/PayPalStandardGatewaySubscriptionModule.php
+++ b/src/NextGen/Gateways/PayPal/PayPalStandardGateway/PayPalStandardGatewaySubscriptionModule.php
@@ -14,7 +14,7 @@ use Give\Subscriptions\ValueObjects\SubscriptionMode;
  * @unreleased
  */
 class PayPalStandardGatewaySubscriptionModule extends SubscriptionModule implements SubscriptionDashboardLinkable,
-                                                                                   SubscriptionAmountEditable
+                                                                                    SubscriptionAmountEditable
 {
     /**
      * @unreleased
@@ -23,8 +23,162 @@ class PayPalStandardGatewaySubscriptionModule extends SubscriptionModule impleme
         Donation $donation,
         Subscription $subscription,
         $gatewayData
-    ) {
-      // TODO: Implement createSubscription() method.
+    )
+    {
+        // TODO: Implement createSubscription() method.
+        /**
+         * Add additional query args to PayPal redirect URLs.
+         * This does not affect the core PayPal Standard gateway functionality.
+         * Later in our routeMethods, there are conditionals to check for these query args
+         * and proceed accordingly if they exist or not making this gateway backwards compatible with legacy forms.
+         *
+         * @see https://developer.paypal.com/api/nvp-soap/paypal-payments-standard/integration-guide/Appx-websitestandard-htmlvariables/#auto-fill-paypal-checkout-page-variables
+         */
+        add_filter(
+            'give_gateway_paypal_redirect_args',
+            static function ($paypalPaymentArguments) use ($gatewayData, $donation, $subscription) {
+                /**
+                 * PayPal Docs:
+                 * The URL to which PayPal redirects buyers' browser after they complete their payments. For example, specify a URL on your site that displays a thank you for your payment page.
+                 *
+                 * By default, PayPal redirects the browser to a PayPal webpage.
+                 *
+                 * Character Length: 1,024
+                 */
+                $paypalPaymentArguments['return'] = add_query_arg(
+                    ['givewp-return-url' => $gatewayData['successUrl']],
+                    $paypalPaymentArguments['return']
+                );
+
+                /**
+                 * PayPal Docs:
+                 *
+                 * A URL to which PayPal redirects the buyers' browsers if they cancel checkout before completing their payments. For example, specify a URL on your website that displays the Payment Canceled page.
+                 *
+                 * By default, PayPal redirects the browser to a PayPal webpage.
+                 *
+                 * Character Length: 1,024
+                 */
+                $paypalPaymentArguments['cancel_return'] = add_query_arg(
+                    ['givewp-return-url' => $gatewayData['cancelUrl']],
+                    $paypalPaymentArguments['cancel_return']
+                );
+
+                /**
+                 * PayPal Docs:
+                 *
+                 * Recurring payments. Subscription payments recur unless subscribers cancel their subscriptions before the end of the current billing cycle or you limit the number of times that payments recur with the value that you specify for srt.
+                 *
+                 * Valid value is:
+                 *
+                 * 0. Subscription payments do not recur.
+                 * 1. Subscription payments recur.
+                 * Default is 0.
+                 */
+                $paypalPaymentArguments['src'] = "1";
+                /**
+                 * PayPal Docs:
+                 * Reattempt on failure. If a recurring payment fails, PayPal attempts to collect the payment two more times before canceling the subscription.
+                 *
+                 * Valid value is:
+                 *
+                 * 0. Do not reattempt failed recurring payments.
+                 * 1. Reattempt failed recurring payments before canceling.
+                 * Default is 1
+                 */
+                $paypalPaymentArguments['sra'] = "1";
+
+                /**
+                 * PayPal Docs:
+                 *
+                 * Return method. The FORM METHOD used to send data to the URL specified by the return variable.
+                 *
+                 * Valid value is:
+                 *
+                 * 0. All shopping cart payments use the GET method.
+                 * 1. The buyer's browser is redirected to the return URL by using the GET method, but no payment variables are included.
+                 * 2. The buyer's browser is redirected to the return URL by using the POST method, and all payment variables are included.
+                 * Default is 0.
+                 */
+                $paypalPaymentArguments['rm'] = 2;
+
+                // PayPal Docs: The button that the person clicked was a Subscribe button.
+                $paypalPaymentArguments['cmd'] = '_xclick-subscriptions';
+
+                // PayPal Docs: Regular subscription price.
+                $paypalPaymentArguments['a3'] = $subscription->amount->formatToDecimal();
+
+                // PayPal Docs: Description of item. If you omit this variable, buyers enter their own name during checkout. Optional for Buy Now, Donate, Subscribe, Automatic Billing, and Add to Cart buttons Character length: 127
+                $paypalPaymentArguments['item_name'] = sprintf(
+                    '%1$s - %2$s',
+                    $donation->formTitle,
+                    $subscription->amount->formatToDecimal()
+                );
+
+                /**
+                 * PayPal Docs:
+                 * Regular subscription units of duration.
+                 *
+                 * Valid value is:
+                 * D. Days. Valid range for p3 is 1 to 90.
+                 * W. Weeks. Valid range for p3 is 1 to 52.
+                 * M. Months. Valid range for p3 is 1 to 24.
+                 * Y. Years. Valid range for p3 is 1 to 5.
+                 * Character Length: 1
+                 */
+                switch ($subscription->period->getValue()) {
+                    case 'day' :
+                        $paypalPaymentArguments['t3'] = 'D';
+                        break;
+                    case 'week' :
+                        $paypalPaymentArguments['t3'] = 'W';
+                        break;
+                    case 'month' :
+                        $paypalPaymentArguments['t3'] = 'M';
+                        break;
+                    case 'year' :
+                        $paypalPaymentArguments['t3'] = 'Y';
+                        break;
+                }
+
+                /**
+                 * PayPal Docs:
+                 *
+                 * Trial period 1 duration. Required if you specify a1. Specify an integer value in the valid range for the units of duration that you specify with t1.
+                 * Character Length: 2
+                 */
+                $paypalPaymentArguments['p1'] = $subscription->frequency;
+                /**
+                 * PayPal Docs:
+                 *
+                 * Subscription duration. Specify an integer value in the Valid range for the units of duration that you specify with t3.
+                 * Character Length: 2
+                 */
+                $paypalPaymentArguments['p3'] = $subscription->frequency;
+
+                if ($subscription->installments > 1) {
+                    // Make sure it's not over the max of 52
+                    $installments = $subscription->installments <= 52 ? $subscription->installments : 52;
+
+                    // PayPal Docs: Recurring times. Number of times that subscription payments recur. Specify an integer with a minimum value of 2 and a maximum value of 52. Valid only if you specify src="1". Character Length: 1
+                    $paypalPaymentArguments['srt'] = $installments;
+                }
+
+
+                /**
+                 * PayPal Docs:
+                 *
+                 * The currency of the payment. Default is USD.
+                 */
+                $paypalPaymentArguments['currency_code'] = $subscription->amount->getCurrency()->getCode();
+
+
+                return $paypalPaymentArguments;
+            }
+        );
+
+        // Re-use the PayPal Standard gateway create payment method to build the args and redirect to PayPal..
+        return give(PayPalStandardGateway::class)->createPayment($donation, $gatewayData);
     }
 
     /**
@@ -40,7 +194,7 @@ class PayPalStandardGatewaySubscriptionModule extends SubscriptionModule impleme
      */
     public function updateSubscriptionAmount(Subscription $subscription, Money $newRenewalAmount)
     {
-       //TODO: Implement updateSubscriptionAmount() method.
+        //TODO: Implement updateSubscriptionAmount() method.
     }
 
     /**
@@ -49,7 +203,7 @@ class PayPalStandardGatewaySubscriptionModule extends SubscriptionModule impleme
     public function gatewayDashboardSubscriptionUrl(Subscription $subscription): string
     {
         //TODO: Implement gatewayDashboardSubscriptionUrl() method.
-        
+
         $url = $subscription->mode->equals(SubscriptionMode::LIVE()) ?
             'https://test.com/' :
             'https://live/';

--- a/src/NextGen/Gateways/PayPal/PayPalStandardGateway/PayPalStandardGatewaySubscriptionModule.php
+++ b/src/NextGen/Gateways/PayPal/PayPalStandardGateway/PayPalStandardGatewaySubscriptionModule.php
@@ -170,10 +170,20 @@ class PayPalStandardGatewaySubscriptionModule extends SubscriptionModule impleme
                  * The currency of the payment. Default is USD.
                  */
                 $paypalPaymentArguments['currency_code'] = $subscription->amount->getCurrency()->getCode();
+
                 if (!empty($invoiceIdPrefix)) {
+                    /**
+                     * PayPal Docs:
+                     *
+                     * Pass-through variable you can use to identify your invoice number for this purchase.
+                     *
+                     * By default, no variable is passed back to you.
+                     *
+                     * Character Length: 127
+                     */
                     $paypalPaymentArguments['invoice'] = trim($invoiceIdPrefix) . $donation->purchaseKey;
                 }
-                
+
                 return $paypalPaymentArguments;
             }
         );

--- a/src/NextGen/ServiceProvider.php
+++ b/src/NextGen/ServiceProvider.php
@@ -13,8 +13,9 @@ use Give\NextGen\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\NextGen\Gateways\NextGenTestGateway\NextGenTestGateway;
 use Give\NextGen\Gateways\NextGenTestGatewayOffsite\NextGenTestGatewayOffsite;
 use Give\NextGen\Gateways\PayPal\PayPalStandardGateway\PayPalStandardGateway;
-use Give\NextGen\Gateways\Stripe\LegacyStripeAdapter;
+use Give\NextGen\Gateways\PayPal\PayPalStandardGateway\PayPalStandardGatewaySubscriptionModule;
 use Give\NextGen\Gateways\PayPalCommerce\PayPalCommerceGateway;
+use Give\NextGen\Gateways\Stripe\LegacyStripeAdapter;
 use Give\NextGen\Gateways\Stripe\NextGenStripeGateway\NextGenStripeGateway;
 use Give\NextGen\Gateways\Stripe\NextGenStripeGateway\NextGenStripeGatewaySubscriptionModule;
 use Give\NextGen\Gateways\Stripe\NextGenStripeGateway\Webhooks\Listeners\ChargeRefunded;
@@ -86,6 +87,13 @@ class ServiceProvider implements ServiceProviderInterface
                 sprintf("givewp_gateway_%s_subscription_module", NextGenStripeGateway::id()),
                 static function () {
                     return NextGenStripeGatewaySubscriptionModule::class;
+                }
+            );
+
+            add_filter(
+                sprintf("givewp_gateway_%s_subscription_module", PayPalStandardGateway::id()),
+                static function () {
+                    return PayPalStandardGatewaySubscriptionModule::class;
                 }
             );
         }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Related: https://github.com/impress-org/givewp/pull/6756, https://github.com/impress-org/give-recurring/pull/1174

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds recurring support for PayPal Standard in Next Gen enabled forms by building a gateway subscription module.  Eventually this module will be moved into give-recurring and replace the legacy paypal standard recurring logic - but for now it lives here just for compatibility with Next Gen forms.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

PayPal standard gateway

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
Using Webhooks (local tunnel)

<img width="731" alt="Screenshot 2023-03-30 at 10 59 27 AM" src="https://user-images.githubusercontent.com/10138447/228879949-f77c626c-a5f5-45c6-bdfd-293efb8d86fd.png">

<img width="1045" alt="Screenshot 2023-03-30 at 10 59 14 AM" src="https://user-images.githubusercontent.com/10138447/228879965-9907ecde-47d4-4ed1-8d50-e235fe2a154f.png">

<img width="931" alt="Screenshot 2023-03-30 at 11 07 05 AM" src="https://user-images.githubusercontent.com/10138447/228880849-eb043f02-c935-4b23-9573-1c821b5c3797.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Setup & enable PayPal standard with test credentials
- Create a next gen form with recurring setup
- Donate using PayPal standard
- (If feeling adventurous you can setup webhooks through a local tunnel but would need to modify the `notify_url` param in paypal args)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

