### PR TITLE
Refactor: Update store as donor meta setting

### DIFF
--- a/packages/form-builder/src/blocks/fields/text/Edit.tsx
+++ b/packages/form-builder/src/blocks/fields/text/Edit.tsx
@@ -66,10 +66,10 @@ export default function Edit({attributes, setAttributes}: BlockEditProps<any>) {
             <InspectorAdvancedControls>
                 <PanelRow>
                     <ToggleControl
-                        label={__('Attach to the Donor', 'give')}
+                        label={__('Save to Donor Record', 'give')}
                         checked={storeAsDonorMeta}
                         onChange={() => setAttributes({storeAsDonorMeta: !storeAsDonorMeta})}
-                        help={__('By default, custom fields are attached to the Donation.', 'give')}
+                        help={__('If enabled, the data collected by this field is saved to the Donor record instead of the Donation record. This is useful for data that doesn't normally change between donations, like a phone number or t-shirt size.', 'give')}
                     />
                 </PanelRow>
                 <PanelRow>

--- a/packages/form-builder/src/blocks/fields/text/Edit.tsx
+++ b/packages/form-builder/src/blocks/fields/text/Edit.tsx
@@ -66,10 +66,10 @@ export default function Edit({attributes, setAttributes}: BlockEditProps<any>) {
             <InspectorAdvancedControls>
                 <PanelRow>
                     <ToggleControl
-                        label={__('Store as Donor Meta', 'give')}
+                        label={__('Attach to the Donor', 'give')}
                         checked={storeAsDonorMeta}
                         onChange={() => setAttributes({storeAsDonorMeta: !storeAsDonorMeta})}
-                        help={__('By default, fields are stored as Donation Meta', 'give')}
+                        help={__('By default, custom fields are attached to the Donation.', 'give')}
                     />
                 </PanelRow>
                 <PanelRow>

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -49,7 +49,7 @@ class FormBuilderViewModelTest extends TestCase
                 'formPage' => [
                     'isEnabled' => give_is_setting_enabled(give_get_option('forms_singular')),
                     // Note: Boolean values must be nested in an array to maintain boolean type, see \WP_Scripts::localize().
-                    'permalink' => add_query_arg(['p' => $formId], site_url()),
+                    'permalink' => add_query_arg(['p' => $formId], site_url('?post_type=give_forms')),
                     'rewriteSlug' => get_post_type_object('give_forms')->rewrite['slug'],
                 ],
             ],


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the label for the "store as donor meta" setting for custom fields.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Before | After |
| -- | --- |
| ![Screenshot 2023-03-31 at 16-08-42 Visual Donation Form Builder Beta ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/229220127-d804a795-1101-45d0-b17f-f80ed7860339.png)  | ![Screenshot 2023-03-31 at 16-09-05 Visual Donation Form Builder Beta ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/229220126-69dd398d-d327-478c-8b39-37eb100a400d.png) |


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203838689047115