### PR TITLE
Fix: height calculation when iframe resizes

### DIFF
--- a/src/NextGen/DonationForm/ViewModels/DonationConfirmationReceiptViewModel.php
+++ b/src/NextGen/DonationForm/ViewModels/DonationConfirmationReceiptViewModel.php
@@ -120,6 +120,7 @@ class DonationConfirmationReceiptViewModel
         endif; ?>
 
         <div data-theme="light" id="root-givewp-donation-confirmation-receipt"
+             data-iframe-height
              class="givewp-donation-confirmation-receipt"
              style="
                      --givewp-primary-color:<?= $primaryColor ?>;

--- a/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
+++ b/src/NextGen/DonationForm/ViewModels/DonationFormViewModel.php
@@ -207,6 +207,7 @@ class DonationFormViewModel
         ?>
 
         <div data-theme="light" id="root-givewp-donation-form"
+             data-iframe-height
              class="<?= implode(' ', $classNames) ?>"></div>
 
         <?php

--- a/src/NextGen/DonationForm/resources/embed.ts
+++ b/src/NextGen/DonationForm/resources/embed.ts
@@ -1,3 +1,3 @@
 import {iframeResize} from 'iframe-resizer';
 
-iframeResize({}, 'iframe[data-givewp-embed]');
+iframeResize({heightCalculationMethod: 'taggedElement'}, 'iframe[data-givewp-embed]');

--- a/src/NextGen/DonationForm/resources/styles/components/_receipt.scss
+++ b/src/NextGen/DonationForm/resources/styles/components/_receipt.scss
@@ -1,6 +1,7 @@
 @use "@picocss/pico/scss/variables";
 
 .givewp-donation-confirmation-receipt {
+    padding: 1rem;
     width: 100%;
     max-width: 100%;
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This resolves an issue when the donation form redirects inside the iframe, the height of the frame is not calculated correctly. 

To fix this I updated our embed implementation of iframeResizer to use the [heightCalculationMethod](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md#heightcalculationmethod) of `'taggedElement'` which is defined here:

> **taggedElement** Finds the bottom of the lowest element with a data-iframe-height attribute
> _The taggedElement option provides much greater performance by limiting the number of elements that need their position checked._

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

When the donation form is inside an iframe, this affects the calculation of it's height.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make a donation using a next gen form and make sure the confirmation page is an appropriate height without a bunch of extra white space on the bottom.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

