### PR TITLE
Chore: update implementation of react render to support react 18 & WordPress 6.2

### DIFF
--- a/src/NextGen/DonationForm/resources/app/DonationFormApp.tsx
+++ b/src/NextGen/DonationForm/resources/app/DonationFormApp.tsx
@@ -1,4 +1,4 @@
-import {render} from '@wordpress/element';
+import {createRoot, render} from '@wordpress/element';
 import getDefaultValuesFromSections from './utilities/getDefaultValuesFromSections';
 import Form from './form/Form';
 import {GiveDonationFormStoreProvider} from './store';
@@ -34,7 +34,7 @@ const initialState = {
 
 function App() {
     if (form.goal.isAchieved) {
-        return <GoalAchievedTemplate goalAchievedMessage={form.settings.goalAchievedMessage}/>;
+        return <GoalAchievedTemplate goalAchievedMessage={form.settings.goalAchievedMessage} />;
     }
 
     return (
@@ -47,4 +47,10 @@ function App() {
     );
 }
 
-render(<App />, document.getElementById('root-givewp-donation-form'));
+const root = document.getElementById('root-givewp-donation-form');
+
+if (createRoot) {
+    createRoot(root).render(<App />);
+} else {
+    render(<App />, root);
+}

--- a/src/NextGen/DonationForm/resources/receipt/DonationConfirmationReceiptApp.tsx
+++ b/src/NextGen/DonationForm/resources/receipt/DonationConfirmationReceiptApp.tsx
@@ -1,4 +1,4 @@
-import {render} from '@wordpress/element';
+import {createRoot, render} from '@wordpress/element';
 import {withTemplateWrapper} from '@givewp/forms/app/templates';
 import amountFormatter from '@givewp/forms/app/utilities/amountFormatter';
 import {ReceiptDetail} from '@givewp/forms/types';
@@ -77,7 +77,11 @@ function DonationConfirmationReceiptApp() {
 
 const root = document.getElementById('root-givewp-donation-confirmation-receipt');
 
-render(<DonationConfirmationReceiptApp />, root);
+if (createRoot) {
+    createRoot(root).render(<DonationConfirmationReceiptApp />);
+} else {
+    render(<DonationConfirmationReceiptApp />, root);
+}
 
 root.scrollIntoView({
     behavior: 'smooth',


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The donation form uses `@wordpress/element` and related packages for react to play nicely with other blocks. It appears newer versions of WordPress are using react 18 where the root rendering api is a little different.  WP [docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/) have a conditional to provide backwards compatibility so this PR updates our implementation to follow that approach.

>Note: createRoot was introduced with React 18, which is bundled with WordPress 6.2. Therefore it may be necessary to mount your component depending on which version of WordPress (and therefore React) you are currently using. This is possible by checking for an undefined import and falling back to the React 17 method of mounting an app using render.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation form and confirmation page rendering.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Run `npm run dev` and make sure the form and confirmation load properly.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

