### PR TITLE
Feature: add backwards compatibility for legacy Stripe webhooks

### DIFF
--- a/give-next-gen.php
+++ b/give-next-gen.php
@@ -9,6 +9,7 @@ use Give\NextGen\CustomFields\ServiceProvider as CustomFieldsServiceProvider;
 use Give\NextGen\DonationForm\ServiceProvider as DonationFormServiceProvider;
 use Give\NextGen\FormPage\ServiceProvider as FormPageServiceProvider;
 use Give\NextGen\Framework\FormDesigns\ServiceProvider as FormDesignServiceProvider;
+use Give\NextGen\Gateways\Stripe\LegacyStripeAdapter;
 use Give\NextGen\ServiceProvider as NextGenServiceProvider;
 use Give\NextGen\WelcomeBanner\ServiceProvider as WelcomeBannerServiceProvider;
 
@@ -53,9 +54,12 @@ register_uninstall_hook(GIVE_NEXT_GEN_FILE, [Activation::class, 'uninstallAddon'
 // Register the add-on service provider with the GiveWP core.
 add_action(
     'before_give_init',
-    function () {
+    static function () {
         // Check Give min required version.
         if (Environment::giveMinRequiredVersionCheck()) {
+            // this needs to load before the LegacyServiceProvider loads in GiveWP.
+            give(LegacyStripeAdapter::class)->addToStripeSupportedPaymentMethodsList();
+
             give()->registerServiceProvider(AddonServiceProvider::class);
             give()->registerServiceProvider(DonationFormServiceProvider::class);
             give()->registerServiceProvider(NextGenServiceProvider::class);

--- a/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
@@ -17,7 +17,7 @@ class LegacyStripeAdapter
      */
     public function addToStripeSupportedPaymentMethodsList()
     {
-        add_action('give_stripe_supported_payment_methods', static function ($gateways) {
+        add_filter('give_stripe_supported_payment_methods', static function ($gateways) {
             $gatewayId = NextGenStripeGateway::id();
 
             if (!in_array($gatewayId, $gateways, true)) {

--- a/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
@@ -13,6 +13,7 @@ class LegacyStripeAdapter
     /**
      * Legacy Stripe gates these files by the use of give_stripe_supported_payment_methods.
      * This makes it possible to load the files without having to enable a legacy stripe gateway.
+     * This also makes it possible to load the files without the use of the give_stripe_supported_payment_methods filter.
      *
      * @unreleased
      */

--- a/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
@@ -18,7 +18,11 @@ class LegacyStripeAdapter
     public function addToStripeSupportedPaymentMethodsList()
     {
         add_action('give_stripe_supported_payment_methods', static function ($gateways) {
-            $gateways[] = NextGenStripeGateway::id();
+            $gatewayId = NextGenStripeGateway::id();
+
+            if (!in_array($gatewayId, $gateways, true)) {
+                $gateways[] = $gatewayId;
+            }
 
             return $gateways;
         });

--- a/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
@@ -9,6 +9,22 @@ use Give\NextGen\Gateways\Stripe\NextGenStripeGateway\NextGenStripeGateway;
 class LegacyStripeAdapter
 {
     /**
+     * This adds the Next Gen Stripe Gateway to the list of give_stripe_supported_payment_methods.
+     *
+     * If this is not included, then the webhooks will not be registered unless a legacy stripe gateway is enabled.
+     *
+     * @unreleased
+     */
+    public function addToStripeSupportedPaymentMethodsList()
+    {
+        add_action('give_stripe_supported_payment_methods', static function ($gateways) {
+            $gateways[] = NextGenStripeGateway::id();
+
+            return $gateways;
+        });
+    }
+
+    /**
      * This adds the Stripe details to the donation details page.
      *
      * @unreleased

--- a/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
@@ -4,10 +4,27 @@ namespace Give\NextGen\Gateways\Stripe;
 
 use Give\Donations\Models\Donation;
 use Give\Helpers\Gateways\Stripe;
+use Give\NextGen\Gateways\NextGenTestGateway\NextGenTestGateway;
 use Give\NextGen\Gateways\Stripe\NextGenStripeGateway\NextGenStripeGateway;
+use Give_Stripe;
 
 class LegacyStripeAdapter
 {
+    /**
+     * Legacy Stripe gates these files by the use of give_stripe_supported_payment_methods.
+     * This makes it possible to load the files without having to enable a legacy stripe gateway.
+     *
+     * @unreleased
+     */
+    public function loadLegacyStripeWebhooksAndFilters()
+    {
+        $gateways = give_get_option('gateways');
+
+        if (!class_exists('Give_Stripe_Webhooks') && array_key_exists(NextGenTestGateway::id(), $gateways)) {
+            (new Give_Stripe())->include_frontend_files();
+        }
+    }
+
     /**
      * This adds the Next Gen Stripe Gateway to the list of give_stripe_supported_payment_methods.
      *

--- a/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
@@ -19,7 +19,17 @@ class LegacyStripeAdapter
      */
     public function loadLegacyStripeWebhooksAndFilters()
     {
-        $gateways = give_get_option('gateways');
+        $settings = give_get_settings();
+        $gatewaysFromSettings = $settings['gateways'] ?? [];
+        $gatewaysFromOption = give_get_option('gateways');
+
+        // for some reason, the gateways from the settings are not always in the gateways from the option.
+        // this might be a service provider race conditions.
+        // for now im merging the two arrays to make sure we're checking both places..
+        $gateways = array_merge(
+            $gatewaysFromOption,
+            $gatewaysFromSettings
+        );
 
         if (!class_exists('Give_Stripe_Webhooks') && array_key_exists(NextGenTestGateway::id(), $gateways)) {
             (new Give_Stripe())->include_frontend_files();

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
@@ -41,7 +41,7 @@ class NextGenStripeGateway extends PaymentGateway implements NextGenPaymentGatew
      */
     public function getName(): string
     {
-        return __('Stripe (Next Gen)', 'give');
+        return __('Stripe - Payment Element (Next Gen)', 'give');
     }
 
     /**

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
@@ -25,7 +25,7 @@ class NextGenStripeGateway extends PaymentGateway implements NextGenPaymentGatew
      */
     public static function id(): string
     {
-        return 'next-gen-stripe';
+        return 'stripe_payment_element';
     }
 
     /**

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/NextGenStripeGateway.php
@@ -49,7 +49,7 @@ class NextGenStripeGateway extends PaymentGateway implements NextGenPaymentGatew
      */
     public function getPaymentMethodLabel(): string
     {
-        return __('Stripe (Next Gen)', 'give');
+        return __('Stripe Payment Element (Next Gen)', 'give');
     }
 
     /**

--- a/src/NextGen/Gateways/Stripe/NextGenStripeGateway/nextGenStripeGateway.tsx
+++ b/src/NextGen/Gateways/Stripe/NextGenStripeGateway/nextGenStripeGateway.tsx
@@ -74,7 +74,7 @@ interface StripeGateway extends Gateway {
 }
 
 const stripeGateway: StripeGateway = {
-    id: 'next-gen-stripe',
+    id: 'stripe_payment_element',
     initialize() {
         const {stripeKey, stripeConnectedAccountId} = this.settings;
 

--- a/src/NextGen/ServiceProvider.php
+++ b/src/NextGen/ServiceProvider.php
@@ -193,6 +193,6 @@ class ServiceProvider implements ServiceProviderInterface
         $legacyStripeAdapter = give(LegacyStripeAdapter::class);
 
         $legacyStripeAdapter->addDonationDetails();
-        $legacyStripeAdapter->addToStripeSupportedPaymentMethodsList();
+        $legacyStripeAdapter->loadLegacyStripeWebhooksAndFilters();
     }
 }

--- a/src/NextGen/ServiceProvider.php
+++ b/src/NextGen/ServiceProvider.php
@@ -127,8 +127,7 @@ class ServiceProvider implements ServiceProviderInterface
             );
         }
 
-        give(LegacyStripeAdapter::class)->addDonationDetails();
-
+        $this->addLegacyStripeAdapter();
         $this->addStripeWebhookListeners();
     }
 
@@ -183,5 +182,17 @@ class ServiceProvider implements ServiceProviderInterface
             'give_recurring_stripe_processing_customer_subscription_deleted',
             CustomerSubscriptionDeleted::class
         );
+    }
+
+    /**
+     * @unreleased
+     */
+    private function addLegacyStripeAdapter()
+    {
+        /** @var LegacyStripeAdapter $legacyStripeAdapter */
+        $legacyStripeAdapter = give(LegacyStripeAdapter::class);
+
+        $legacyStripeAdapter->addDonationDetails();
+        $legacyStripeAdapter->addToStripeSupportedPaymentMethodsList();
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Depends on (but not completely): https://github.com/impress-org/givewp/pull/6768

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We discovered that (currently), one of the existing Stripe gateways must be enabled in order for the Stripe webhooks to run.  This adds our new Stripe gateway to that list using a new filter `give_stripe_supported_payment_methods`.

Also included is a direct call to the legacy class to include the necessary files if this filter is not being used.  It checks if the `Give_Stripe_Webhooks` exists and if the new Stripe gateway is enabled.  This will make this backwards compatible regardless of the filter.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- This will make our new `NextGenStripeGateway` not have to rely on a legacy Stripe gateway to be enabled for webhooks to work properly.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Test the Stripe webhook with only the next gen gateway enabled.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

