### PR TITLE
Fix: add check for isGiveActive in activation hook

### DIFF
--- a/src/Addon/Activation.php
+++ b/src/Addon/Activation.php
@@ -21,6 +21,10 @@ class Activation
      */
     public static function activateAddon()
     {
+        if (!Environment::isGiveActive()) {
+            return;
+        }
+
         $gateways = give_get_option('gateways');
 
         if (!array_key_exists(NextGenTestGateway::id(), $gateways)) {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This prevents a fatal error on activation when GiveWP is not installed.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The activation hook.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="987" alt="Screenshot 2023-04-07 at 3 21 15 PM" src="https://user-images.githubusercontent.com/10138447/230665348-8a44c1fd-18b0-41df-84c8-aa96abdd9dd5.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Try activating this plugin without GiveWP.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

