### PR TITLE
Fix: Correct reference to Stripe Next Gen gateway when loading legacy Stripe code

### DIFF
--- a/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/NextGen/Gateways/Stripe/LegacyStripeAdapter.php
@@ -15,6 +15,7 @@ class LegacyStripeAdapter
      * This makes it possible to load the files without having to enable a legacy stripe gateway.
      * This also makes it possible to load the files without the use of the give_stripe_supported_payment_methods filter.
      *
+     * @unreleased Fix reference to Next Gen gateway when loading Stripe (legacy) code.
      * @since 0.3.0
      */
     public function loadLegacyStripeWebhooksAndFilters()
@@ -31,7 +32,7 @@ class LegacyStripeAdapter
             $gatewaysFromSettings
         );
 
-        if (!class_exists('Give_Stripe_Webhooks') && array_key_exists(NextGenTestGateway::id(), $gateways)) {
+        if (!class_exists('Give_Stripe_Webhooks') && array_key_exists(NextGenStripeGateway::id(), $gateways)) {
             (new Give_Stripe())->include_frontend_files();
         }
     }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

As reported by @Benunc, the Next Gen feature plugin was causing a break in form styles for the (legacy) Multi-Part template. I narrowed down the issue to the Next Gen Test Gateway and the (legacy) Stripe front-end files, which are included for the webhook listeners.

The `loadLegacyStripeWebhooksAndFilters()` method was checking for the `NextGenTestGateway::class` to be "active", but should instead have been checking for the `NextGenStripeGateway::class` - a simple typo in the code and oversight during code review.

Additionally, there issue revealed a bug in the legacy Stripe code, in which a callback for the filter hook `give_form_html_tags` returned `false` if no Stripe gateways were active when the filter hook expects an array to always be returned.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Broken | Fixed |
| --- | --- |
![image](https://user-images.githubusercontent.com/10858303/231225015-a653d0b3-53c7-4da1-9cda-ce9bc49c523c.png) | ![image](https://user-images.githubusercontent.com/10858303/231225126-89481309-0db1-4e79-a258-4ebc3ef9fc02.png) |

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Using a (legacy) Multi-Part form template:

- Toggle the Next Gen _Test_ Gateway
- Check the form field styles


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204358626491010