### PR TITLE
Feature: Add notice for recurring gateways

### DIFF
--- a/packages/form-builder/src/blocks/fields/amount/Edit.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/Edit.tsx
@@ -30,7 +30,8 @@ const Edit = ({attributes, setAttributes}) => {
     } = attributes;
 
     const {gateways} = getFormBuilderData();
-    const isRecurringSupported = gateways.some((gateway) => gateway.supportsSubscriptions);
+
+    const isRecurringSupported = gateways.some((gateway) => gateway.enabled && gateway.supportsSubscriptions);
     const isRecurring = isRecurringSupported && recurringEnabled;
     const isMultiLevel = priceOption === 'multi';
     const isFixedAmount = priceOption === 'set';

--- a/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -14,6 +14,7 @@ import AddButton from './add-button';
 import {CurrencyControl} from '@givewp/form-builder/common/currency';
 import periodLookup from '../period-lookup';
 import RecurringDonationsPromo from '@givewp/form-builder/promos/recurring-donations';
+import PromoContainer from '@givewp/form-builder/promos/container';
 import {getFormBuilderData} from '@givewp/form-builder/common/getWindowData';
 import Label from '@givewp/form-builder/blocks/fields/settings/Label';
 
@@ -48,8 +49,10 @@ const Inspector = ({attributes, setAttributes}) => {
         }
     };
 
-    const {gateways} = getFormBuilderData();
-    const isRecurringSupported = gateways.some((gateway) => gateway.supportsSubscriptions);
+    const {gateways, isRecurringEnabled, gatewaySettingsUrl} = getFormBuilderData();
+    const enabledGateways = gateways.filter((gateway) => gateway.enabled);
+    const recurringGateways = gateways.filter((gateway) => gateway.supportsSubscriptions);
+    const isRecurringSupported = enabledGateways.some((gateway) => gateway.supportsSubscriptions);
     const isRecurring = isRecurringSupported && recurringEnabled;
 
     return (
@@ -164,7 +167,24 @@ const Inspector = ({attributes, setAttributes}) => {
                 </PanelBody>
             )}
             <PanelBody title={__('Recurring Donations', 'give')} initialOpen={false}>
-                {!isRecurringSupported && <RecurringDonationsPromo />}
+                {!isRecurringSupported && (
+                    isRecurringEnabled
+                        ? <div style={{
+                            fontSize: '13px',
+                            lineHeight: '1.3em',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '12px',
+                            padding: '6px 12px 12px 0',
+                        }}>
+                            <div>None of the payment gateways currently enabled support Recurring Donations. To collect recurring donations, enable one of the following payment gateways:</div>
+                            <ul style={{listStyleType: 'inherit', marginLeft: '12px'}}>
+                                {recurringGateways.map((gateway) => <li key={gateway.id}>{gateway.label}</li>)}
+                            </ul>
+                            <a href={gatewaySettingsUrl} target="_blank" rel="noreferrer noopener">Go to Payment Gateway Settings</a>
+                        </div>
+                        : <RecurringDonationsPromo />
+                )}
 
                 {isRecurringSupported && (
                     <PanelRow>

--- a/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -48,7 +48,7 @@ const Inspector = ({attributes, setAttributes}) => {
         }
     };
 
-    const {gateways, isRecurringEnabled, gatewaySettingsUrl} = getFormBuilderData();
+    const {gateways, recurringAddonData, gatewaySettingsUrl} = getFormBuilderData();
     const enabledGateways = gateways.filter((gateway) => gateway.enabled);
     const recurringGateways = gateways.filter((gateway) => gateway.supportsSubscriptions);
     const isRecurringSupported = enabledGateways.some((gateway) => gateway.supportsSubscriptions);
@@ -167,7 +167,7 @@ const Inspector = ({attributes, setAttributes}) => {
             )}
             <PanelBody title={__('Recurring Donations', 'give')} initialOpen={false}>
                 {!isRecurringSupported && (
-                    isRecurringEnabled
+                    recurringAddonData.isInstalled
                         ? <div style={{
                             fontSize: '13px',
                             lineHeight: '1.3em',

--- a/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -14,7 +14,6 @@ import AddButton from './add-button';
 import {CurrencyControl} from '@givewp/form-builder/common/currency';
 import periodLookup from '../period-lookup';
 import RecurringDonationsPromo from '@givewp/form-builder/promos/recurring-donations';
-import PromoContainer from '@givewp/form-builder/promos/container';
 import {getFormBuilderData} from '@givewp/form-builder/common/getWindowData';
 import Label from '@givewp/form-builder/blocks/fields/settings/Label';
 

--- a/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -176,7 +176,7 @@ const Inspector = ({attributes, setAttributes}) => {
                             gap: '12px',
                             padding: '6px 12px 12px 0',
                         }}>
-                            <div>None of the payment gateways currently enabled support Recurring Donations. To collect recurring donations, enable one of the following payment gateways:</div>
+                            <div>{__('None of the payment gateways currently enabled support Recurring Donations. To collect recurring donations, enable one of the following payment gateways:', 'give')}</div>
                             <ul style={{listStyleType: 'inherit', marginLeft: '12px'}}>
                                 {recurringGateways.map((gateway) => <li key={gateway.id}>{gateway.label}</li>)}
                             </ul>

--- a/packages/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
+++ b/packages/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
@@ -32,7 +32,7 @@ export default function Edit(props: BlockEditProps<any>) {
             }}
         >
             <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
-                {gateways.map((gateway) => (
+                {gateways.filter(gateway => gateway.enabled).map((gateway) => (
                     <GatewayItem
                         key={gateway.id}
                         label={gateway.label}

--- a/packages/form-builder/src/common/getWindowData.ts
+++ b/packages/form-builder/src/common/getWindowData.ts
@@ -9,6 +9,8 @@ declare global {
         },
         formBuilderData?: {
             gateways: Gateway[];
+            isRecurringEnabled: string;
+            gatewaySettingsUrl: string;
         },
     }
 }

--- a/packages/form-builder/src/common/getWindowData.ts
+++ b/packages/form-builder/src/common/getWindowData.ts
@@ -9,7 +9,9 @@ declare global {
         },
         formBuilderData?: {
             gateways: Gateway[];
-            isRecurringEnabled: string;
+            recurringAddonData?: {
+                isInstalled: boolean;
+            },
             gatewaySettingsUrl: string;
         },
     }

--- a/packages/form-builder/src/types/gateways.ts
+++ b/packages/form-builder/src/types/gateways.ts
@@ -1,5 +1,6 @@
 export type Gateway = {
     id: string;
+    enabled: boolean;
     label: string;
     supportsSubscriptions: boolean;
 }

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -7,6 +7,7 @@ use Give\FormBuilder\ViewModels\FormBuilderViewModel;
 use Give\Framework\EnqueueScript;
 
 use Give\Framework\PaymentGateways\Contracts\NextGenPaymentGatewayInterface;
+use Give\Framework\PaymentGateways\PaymentGatewayRegister;
 use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
 
 use function wp_enqueue_style;
@@ -85,20 +86,24 @@ class RegisterFormBuilderPageRoute
 
         $formBuilderStorage->loadInFooter()->enqueue();
 
-        $enabledGateways = array_filter(
-            give(DonationFormRepository::class)->getEnabledPaymentGateways($donationFormId),
+        $enabledGateways = array_keys(give_get_option('gateways'));
+
+        $supportedGateways = array_filter(
+            give(PaymentGatewayRegister::class)->getPaymentGateways(),
             static function ($gateway) {
-                return $gateway instanceof NextGenPaymentGatewayInterface;
+                return is_a($gateway, NextGenPaymentGatewayInterface::class, true);
             }
         );
 
-        $builderPaymentGatewayData = array_map(function ($gateway) {
+        $builderPaymentGatewayData = array_map(static function ($gatewayClass) use ($enabledGateways) {
+            $gateway = give($gatewayClass);
             return [
                 'id' => $gateway::id(),
+                'enabled' => in_array($gateway::id(), $enabledGateways, true),
                 'label' => give_get_gateway_checkout_label($gateway::id()) ?? $gateway->getPaymentMethodLabel(),
                 'supportsSubscriptions' => $gateway->supportsSubscriptions(),
             ];
-        }, $enabledGateways);
+        }, $supportedGateways);
 
         (new EnqueueScript(
             '@givewp/form-builder/script',
@@ -109,6 +114,8 @@ class RegisterFormBuilderPageRoute
         ))->loadInFooter()
             ->registerLocalizeData('formBuilderData', [
                 'gateways' => array_values($builderPaymentGatewayData),
+                'isRecurringEnabled' => defined('GIVE_RECURRING_VERSION') ? GIVE_RECURRING_VERSION : null,
+                'gatewaySettingsUrl' => admin_url('edit.php?post_type=give_forms&page=give-settings&tab=gateways'),
             ])
             ->enqueue();
 

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -115,6 +115,9 @@ class RegisterFormBuilderPageRoute
             ->registerLocalizeData('formBuilderData', [
                 'gateways' => array_values($builderPaymentGatewayData),
                 'isRecurringEnabled' => defined('GIVE_RECURRING_VERSION') ? GIVE_RECURRING_VERSION : null,
+                'recurringAddonData' => [
+                    'isInstalled' => defined('GIVE_RECURRING_VERSION') ,
+                ],
                 'gatewaySettingsUrl' => admin_url('edit.php?post_type=give_forms&page=give-settings&tab=gateways'),
             ])
             ->enqueue();


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new notice, under the "Recurring Donations" settings of the Amount field block, that instructs the user to enable a gateways that supports recurring.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This updates the way that gateways data is aggregated in the form builder in order to account for non-enabled gateways.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/232126441-cbe9d81e-3b46-444d-ace0-8d3d61e2a07c.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Enable the Recurring add-on, but disable all Next Gen gateways that support recurring.
