### PR TITLE
Fix: Move editor out from under header in the Custom Styles modal

### DIFF
--- a/packages/form-builder/src/settings/styles/index.tsx
+++ b/packages/form-builder/src/settings/styles/index.tsx
@@ -47,7 +47,7 @@ const CustomStyleSettings = () => {
                         right: '0',
                     }}>
                         <div style={{
-                            margin: '-25px -31px -23px -31px', // Offset the modal padding in order to fill the available space.
+                            margin: '0 -31px -23px -31px', // Offset the modal padding in order to fill the available space.
                         }}>
                             <CustomStyleCodeControl />
                         </div>


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR removes the top margin offset from the code editor in the Custom Styles modal so that the editor is no longer hidden by the header.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| After |
| --- |
|![image](https://user-images.githubusercontent.com/10858303/232127773-c14157e4-c73f-465b-b34e-7feed9dc081a.png)|

| Before |
| --- |
| ![image](https://user-images.githubusercontent.com/10858303/232130204-a41dcc9f-926d-4f7b-aebc-908d040f89e0.png) |

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
 
In the Design tab, under the Custom Styles section, open the custom styles modal.