### PR TITLE
Fix: ability to add empty section in form builder

### DIFF
--- a/src/NextGen/DonationForm/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/NextGen/DonationForm/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -61,8 +61,7 @@ class ConvertDonationFormBlocksToFieldsApi
             ->label($block->getAttribute('title'))
             ->description($block->getAttribute('description'))
             ->append(
-                ...
-                array_map([$this, 'convertInnerBlockToNode'],
+                ...array_map([$this, 'convertInnerBlockToNode'],
                     $block->innerBlocks ? $block->innerBlocks->getBlocks() : [])
             );
     }

--- a/src/NextGen/DonationForm/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/NextGen/DonationForm/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -60,13 +60,17 @@ class ConvertDonationFormBlocksToFieldsApi
         return Section::make($block->getShortName() . '-' . $blockIndex)
             ->label($block->getAttribute('title'))
             ->description($block->getAttribute('description'))
-            ->append(...array_map([$this, 'convertInnerBlockToNode'], $block->innerBlocks->getBlocks()));
+            ->append(
+                ...
+                array_map([$this, 'convertInnerBlockToNode'],
+                    $block->innerBlocks ? $block->innerBlocks->getBlocks() : [])
+            );
     }
 
     /**
      * @since 0.1.0
      *
-     * @throws EmptyNameException
+     * @throws EmptyNameException|NameCollisionException
      */
     protected function convertInnerBlockToNode(BlockModel $block): Node
     {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #168

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This makes it possible to add an empty section to the form builder without any child blocks.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form builder, adding an empty section and saving.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Pull branch
- Try adding an empty section and saving the form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

