### PR TITLE
Fix: use label attribute setting for amount field

### DIFF
--- a/src/NextGen/DonationForm/Actions/ConvertDonationAmountBlockToFieldsApi.php
+++ b/src/NextGen/DonationForm/Actions/ConvertDonationAmountBlockToFieldsApi.php
@@ -57,7 +57,7 @@ class ConvertDonationAmountBlockToFieldsApi
             /** @var Amount $amountNode */
             $amountNode = $group->getNodeByName('amount');
             $amountNode
-                ->label(__('Donation Amount', 'give'))
+                ->label($block->getAttribute('label'))
                 ->levels(...array_map('absint', $block->getAttribute('levels')))
                 ->allowLevels($block->getAttribute('priceOption') === 'multi')
                 ->allowCustomAmount($block->getAttribute('customAmount'))


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #170

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This was in place from [this](https://github.com/impress-org/givewp-next-gen/pull/146) PR but looks like it was reverted from a merge or something.  This adds the dynamic label back to the block conversion.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The amount field block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="689" alt="Screenshot 2023-04-17 at 1 33 39 PM" src="https://user-images.githubusercontent.com/10138447/232565325-1059e443-36ff-4110-8ade-1866e5d45419.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Pull branch
- Update the amount label
- Make sure it is reflected on the donation form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

