### PR TITLE
Fix: update subscription amount label in confirmation page & donation summary

### DIFF
--- a/src/NextGen/DonationForm/resources/registrars/templates/elements/DonationSummary.tsx
+++ b/src/NextGen/DonationForm/resources/registrars/templates/elements/DonationSummary.tsx
@@ -1,9 +1,11 @@
 import {__} from '@wordpress/i18n';
 import useCurrencyFormatter from '@givewp/forms/app/hooks/useCurrencyFormatter';
 import {isSubscriptionPeriod, SubscriptionPeriod} from '../groups/DonationAmount/subscriptionPeriod';
-import {useCallback} from 'react';
+import {ReactElement, useCallback} from 'react';
+import {createInterpolateElement} from '@wordpress/element';
 
 /**
+ * @unreleased update subscription frequency label
  * @since 0.1.0
  */
 export default function DonationSummary() {
@@ -11,11 +13,20 @@ export default function DonationSummary() {
     const currency = useWatch({name: 'currency'});
     const amount = useWatch({name: 'amount'});
     const period = useWatch({name: 'subscriptionPeriod'});
+    const frequency = useWatch({name: 'subscriptionFrequency'});
     const formatter = useCurrencyFormatter(currency, {});
 
     const givingFrequency = useCallback(() => {
         if (isSubscriptionPeriod(period)) {
-            return new SubscriptionPeriod(period).label().capitalize().adjective();
+            const subscriptionPeriod = new SubscriptionPeriod(period);
+
+            if (frequency > 1) {
+                return createInterpolateElement(__('Every <period />', 'give'), {
+                    period: <span>{`${frequency} ${subscriptionPeriod.label().plural()}`}</span>,
+                });
+            } else {
+                return subscriptionPeriod.label().capitalize().adjective();
+            }
         }
 
         return __('One time', 'give');
@@ -33,7 +44,7 @@ export default function DonationSummary() {
 /**
  * @since 0.1.0
  */
-const LineItem = ({label, value}: {label: string; value: string}) => {
+const LineItem = ({label, value}: { label: string; value: string | ReactElement }) => {
     return (
         <li className="givewp-elements-donationSummary__list-item">
             <div>{label}</div>

--- a/src/NextGen/DonationForm/resources/registrars/templates/elements/DonationSummary.tsx
+++ b/src/NextGen/DonationForm/resources/registrars/templates/elements/DonationSummary.tsx
@@ -24,9 +24,9 @@ export default function DonationSummary() {
                 return createInterpolateElement(__('Every <period />', 'give'), {
                     period: <span>{`${frequency} ${subscriptionPeriod.label().plural()}`}</span>,
                 });
-            } else {
-                return subscriptionPeriod.label().capitalize().adjective();
             }
+
+            return subscriptionPeriod.label().capitalize().adjective();
         }
 
         return __('One time', 'give');

--- a/src/NextGen/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/NextGen/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -157,6 +157,10 @@ class GenerateConfirmationPageReceipt
     {
         if ($receipt->donation->subscriptionId) {
             $subscription = $receipt->donation->subscription;
+            $subscriptionAmountLabel = sprintf(
+                $subscription->period->label($subscription->frequency),
+                $subscription->frequency
+            );
 
             $receipt->subscriptionDetails->addDetails([
                 new ReceiptDetail(
@@ -166,7 +170,7 @@ class GenerateConfirmationPageReceipt
                             sprintf(
                                 '%s / %s',
                                 $subscription->amount->formatToDecimal(),
-                                $subscription->period->getValue()
+                                $subscriptionAmountLabel
                             )
                     ]
                 ),

--- a/src/NextGen/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/NextGen/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -149,6 +149,7 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
+     * @unreleased update subscription amount label with frequency
      * @since 0.1.0
      *
      * @return void

--- a/tests/Unit/Framework/Receipts/TestGenerateConfirmationPageReceipt.php
+++ b/tests/Unit/Framework/Receipts/TestGenerateConfirmationPageReceipt.php
@@ -141,6 +141,11 @@ class TestGenerateConfirmationPageReceipt extends TestCase
             ),
         ]);
 
+        $subscriptionAmountLabel = sprintf(
+            $subscription->period->label($subscription->frequency),
+            $subscription->frequency
+        );
+
         $subscriptionDetails = new ReceiptDetailCollection([
             new ReceiptDetail(
                 __('Subscription', 'give'),
@@ -149,7 +154,7 @@ class TestGenerateConfirmationPageReceipt extends TestCase
                         sprintf(
                             '%s / %s',
                             $subscription->amount->formatToDecimal(),
-                            $subscription->period->getValue()
+                            $subscriptionAmountLabel
                         )
                 ]
             ),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #172

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the confirmation page to display the subscription amount label with the correct frequency & period settings.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The confirmation page.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Confirmation Page:**

<img width="814" alt="Screenshot 2023-04-17 at 1 53 02 PM" src="https://user-images.githubusercontent.com/10138447/232570761-8e6d5e80-262a-426a-85d1-3d62a730aca8.png">

**Donation Summary**

<img width="694" alt="Screenshot 2023-04-17 at 2 19 49 PM" src="https://user-images.githubusercontent.com/10138447/232575503-73a43e63-fed9-4499-be5b-8d087c8eb434.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- Setup a form with recurring every 2 months
- Make a donation/subscription using the form
- Make sure the donation summary looks right.
- Make sure the subscription amount looks right.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

