### PR TITLE
Refactor: form builder to use wp-scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,10 +1961,11 @@
             }
         },
         "node_modules/@floating-ui/react-dom": {
-            "version": "1.2.1",
-            "license": "MIT",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
+            "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
             "dependencies": {
-                "@floating-ui/dom": "^1.1.0"
+                "@floating-ui/dom": "^1.0.0"
             },
             "peerDependencies": {
                 "react": ">=16.8.0",
@@ -2813,58 +2814,6 @@
             "version": "2.0.4",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@motionone/animation": {
-            "version": "10.15.1",
-            "license": "MIT",
-            "dependencies": {
-                "@motionone/easing": "^10.15.1",
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@motionone/dom": {
-            "version": "10.15.5",
-            "license": "MIT",
-            "dependencies": {
-                "@motionone/animation": "^10.15.1",
-                "@motionone/generators": "^10.15.1",
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
-                "hey-listen": "^1.0.8",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@motionone/easing": {
-            "version": "10.15.1",
-            "license": "MIT",
-            "dependencies": {
-                "@motionone/utils": "^10.15.1",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@motionone/generators": {
-            "version": "10.15.1",
-            "license": "MIT",
-            "dependencies": {
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@motionone/types": {
-            "version": "10.15.1",
-            "license": "MIT"
-        },
-        "node_modules/@motionone/utils": {
-            "version": "10.15.1",
-            "license": "MIT",
-            "dependencies": {
-                "@motionone/types": "^10.15.1",
-                "hey-listen": "^1.0.8",
-                "tslib": "^2.3.1"
-            }
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
@@ -4637,14 +4586,16 @@
             }
         },
         "node_modules/@use-gesture/core": {
-            "version": "10.2.23",
-            "license": "MIT"
+            "version": "10.2.26",
+            "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.26.tgz",
+            "integrity": "sha512-NyFpQ3iID9iFBROXyyvU1D0NK+t+dP+WAVByhCvqHUenpxLD2NlRLVRpoK3XGGwksr6mU3PvZ2Nm4q0q+gLJPA=="
         },
         "node_modules/@use-gesture/react": {
-            "version": "10.2.23",
-            "license": "MIT",
+            "version": "10.2.26",
+            "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.26.tgz",
+            "integrity": "sha512-0QhaE5mhaQbFlip4MX7n1nwCX8gax6Da1LsP2fZ/BU6xW9zyEmV6NX7DPelDxq1rr2NiBJh30vx9RIp80YeA/A==",
             "dependencies": {
-                "@use-gesture/core": "10.2.23"
+                "@use-gesture/core": "10.2.26"
             },
             "peerDependencies": {
                 "react": ">= 16.8.0"
@@ -4815,32 +4766,35 @@
             }
         },
         "node_modules/@wordpress/a11y": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.32.0.tgz",
+            "integrity": "sha512-eUlQUqF9iL6cumhKWG5YZ7ywN/WWdlUpQzZ4B4SKVUcJvZty8fpWQfko0GpPpuGN2l7aFacs3NlfzYvUVn4wNQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/dom-ready": "^3.25.0",
-                "@wordpress/i18n": "^4.25.0"
+                "@wordpress/dom-ready": "^3.32.0",
+                "@wordpress/i18n": "^4.32.0"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@wordpress/api-fetch": {
-            "version": "6.22.0",
-            "license": "GPL-2.0-or-later",
+            "version": "6.29.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.29.0.tgz",
+            "integrity": "sha512-6qtKZbS6mQl0PQhTB6BX9f9n3ika+R2RH+AqIQHiQH2yMulWlcaW6s/aOMLhEdXKPgG7geDqTdcASDJluV1yhQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/i18n": "^4.25.0",
-                "@wordpress/url": "^3.26.0"
+                "@wordpress/i18n": "^4.32.0",
+                "@wordpress/url": "^3.33.0"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@wordpress/autop": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.32.0.tgz",
+            "integrity": "sha512-k4p+Tse7x58gV3bw7aMzUi4cp7evtXDy6GmtQaF8MDM2Q43aJuvHKJD0AIFCzcCWir7y5X4fOyUxO/5TOh1vmg==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -4887,8 +4841,9 @@
             "license": "GPL-2.0-or-later"
         },
         "node_modules/@wordpress/blob": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.32.0.tgz",
+            "integrity": "sha512-0ruTze+Qp/O3n0m5uD61O1uP258AvHls0JfWKt5zAytbH1HwIqpIj3ApzKmcwmOI170QpGGS/ppZvJCkYftVQQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5003,8 +4958,9 @@
             }
         },
         "node_modules/@wordpress/block-serialization-default-parser": {
-            "version": "4.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.32.0.tgz",
+            "integrity": "sha512-MRguQlh8oXS5+csKCmD61g22cLHU8OegiLWk6COpmXHMFL9X3SIpTgBis7c8kyo3Iqg9edO5gD1Wf1OciNX9Pw==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5013,23 +4969,25 @@
             }
         },
         "node_modules/@wordpress/blocks": {
-            "version": "12.2.0",
-            "license": "GPL-2.0-or-later",
+            "version": "12.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.9.0.tgz",
+            "integrity": "sha512-11X8dHqj+ITn/XKpa69eVHxDXQaK6jgaPm8lWllAiTAO7ICappVrWMFeYB7qYka2+nQQftdiAlVoAA4yD/nTxA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/autop": "^3.25.0",
-                "@wordpress/blob": "^3.25.0",
-                "@wordpress/block-serialization-default-parser": "^4.25.0",
-                "@wordpress/compose": "^6.2.0",
-                "@wordpress/data": "^8.2.0",
-                "@wordpress/deprecated": "^3.25.0",
-                "@wordpress/dom": "^3.25.0",
-                "@wordpress/element": "^5.2.0",
-                "@wordpress/hooks": "^3.25.0",
-                "@wordpress/html-entities": "^3.25.0",
-                "@wordpress/i18n": "^4.25.0",
-                "@wordpress/is-shallow-equal": "^4.25.0",
-                "@wordpress/shortcode": "^3.25.0",
+                "@wordpress/autop": "^3.32.0",
+                "@wordpress/blob": "^3.32.0",
+                "@wordpress/block-serialization-default-parser": "^4.32.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/data": "^9.2.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/hooks": "^3.32.0",
+                "@wordpress/html-entities": "^3.32.0",
+                "@wordpress/i18n": "^4.32.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/shortcode": "^3.32.0",
                 "change-case": "^4.1.2",
                 "colord": "^2.7.0",
                 "fast-deep-equal": "^3.1.3",
@@ -5037,11 +4995,64 @@
                 "is-plain-object": "^5.0.0",
                 "lodash": "^4.17.21",
                 "memize": "^1.1.0",
-                "rememo": "^4.0.0",
+                "rememo": "^4.0.2",
                 "remove-accents": "^0.4.2",
                 "showdown": "^1.9.1",
                 "simple-html-tokenizer": "^0.5.7",
                 "uuid": "^8.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/blocks/node_modules/@wordpress/compose": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.9.0.tgz",
+            "integrity": "sha512-5uWC2hzhXtrBBgVsVSO5sjEt2NjgblYpPO99pD6K8zlXni0rs60cQVGcUPmOsusbQen9vJbnfYvoXPnVAbTLRw==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/mousetrap": "^1.6.8",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "change-case": "^4.1.2",
+                "clipboard": "^2.0.8",
+                "mousetrap": "^1.6.5",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.2.0.tgz",
+            "integrity": "sha512-7LIklCC9zc9kG8zVQquniEnX0KLL8J5n7WWY/AWYLOHFnjKQR65mzF5KaMl6YX041oWsDGaKBKzLvWOm23KWlA==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/redux-routine": "^4.32.0",
+                "deepmerge": "^4.3.0",
+                "equivalent-key-map": "^0.2.2",
+                "is-plain-object": "^5.0.0",
+                "is-promise": "^4.0.0",
+                "redux": "^4.1.2",
+                "turbo-combine-reducers": "^1.0.2",
+                "use-memo-one": "^1.1.1"
             },
             "engines": {
                 "node": ">=12"
@@ -5059,8 +5070,9 @@
             }
         },
         "node_modules/@wordpress/components": {
-            "version": "23.2.0",
-            "license": "GPL-2.0-or-later",
+            "version": "23.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-23.9.0.tgz",
+            "integrity": "sha512-hEgzWe6PSWlUXPRcYX8YyQhL5Wp6TRqmzv+jIDJnYKXZH1UvsK/WcfCtdIOx7Q7oaPKDtH3vdv+0twcrHeN/bA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "@emotion/cache": "^11.7.1",
@@ -5069,42 +5081,46 @@
                 "@emotion/serialize": "^1.0.2",
                 "@emotion/styled": "^11.6.0",
                 "@emotion/utils": "^1.0.0",
-                "@floating-ui/react-dom": "^1.0.0",
-                "@use-gesture/react": "^10.2.6",
-                "@wordpress/a11y": "^3.25.0",
-                "@wordpress/compose": "^6.2.0",
-                "@wordpress/date": "^4.25.0",
-                "@wordpress/deprecated": "^3.25.0",
-                "@wordpress/dom": "^3.25.0",
-                "@wordpress/element": "^5.2.0",
-                "@wordpress/escape-html": "^2.25.0",
-                "@wordpress/hooks": "^3.25.0",
-                "@wordpress/i18n": "^4.25.0",
-                "@wordpress/icons": "^9.16.0",
-                "@wordpress/is-shallow-equal": "^4.25.0",
-                "@wordpress/keycodes": "^3.25.0",
-                "@wordpress/primitives": "^3.23.0",
-                "@wordpress/rich-text": "^6.2.0",
-                "@wordpress/warning": "^2.25.0",
+                "@floating-ui/react-dom": "1.0.0",
+                "@use-gesture/react": "^10.2.24",
+                "@wordpress/a11y": "^3.32.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/date": "^4.32.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/escape-html": "^2.32.0",
+                "@wordpress/hooks": "^3.32.0",
+                "@wordpress/html-entities": "^3.32.0",
+                "@wordpress/i18n": "^4.32.0",
+                "@wordpress/icons": "^9.23.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/primitives": "^3.30.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/rich-text": "^6.9.0",
+                "@wordpress/warning": "^2.32.0",
                 "change-case": "^4.1.2",
                 "classnames": "^2.3.1",
                 "colord": "^2.7.0",
                 "date-fns": "^2.28.0",
+                "deepmerge": "^4.3.0",
                 "dom-scroll-into-view": "^1.2.1",
                 "downshift": "^6.0.15",
                 "fast-deep-equal": "^3.1.3",
-                "framer-motion": "^7.6.1",
+                "framer-motion": "^10.11.6",
                 "gradient-parser": "^0.1.5",
                 "highlight-words-core": "^1.2.2",
-                "lodash": "^4.17.21",
+                "is-plain-object": "^5.0.0",
                 "memize": "^1.1.0",
+                "path-to-regexp": "^6.2.1",
                 "re-resizable": "^6.4.0",
                 "react-colorful": "^5.3.1",
-                "reakit": "^1.3.8",
+                "reakit": "^1.3.11",
                 "remove-accents": "^0.4.2",
                 "use-lilius": "^2.0.1",
                 "uuid": "^8.3.0",
-                "valtio": "^1.7.0"
+                "valtio": "1.7.0"
             },
             "engines": {
                 "node": ">=12"
@@ -5113,6 +5129,36 @@
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0"
             }
+        },
+        "node_modules/@wordpress/components/node_modules/@wordpress/compose": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.9.0.tgz",
+            "integrity": "sha512-5uWC2hzhXtrBBgVsVSO5sjEt2NjgblYpPO99pD6K8zlXni0rs60cQVGcUPmOsusbQen9vJbnfYvoXPnVAbTLRw==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/mousetrap": "^1.6.8",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "change-case": "^4.1.2",
+                "clipboard": "^2.0.8",
+                "mousetrap": "^1.6.5",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/components/node_modules/path-to-regexp": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
         },
         "node_modules/@wordpress/compose": {
             "version": "6.2.0",
@@ -5195,13 +5241,14 @@
             }
         },
         "node_modules/@wordpress/date": {
-            "version": "4.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.32.0.tgz",
+            "integrity": "sha512-PNPHkSh1cgzG8+O0xO93yE+JIx6B30Qdjyk8HaDvUT+jj0q/uWhcEjOr/0jmLBdHEqjoVzUE9MPtkzcVGaTLJg==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/deprecated": "^3.25.0",
-                "moment": "^2.22.1",
-                "moment-timezone": "^0.5.31"
+                "@wordpress/deprecated": "^3.32.0",
+                "moment": "^2.29.4",
+                "moment-timezone": "^0.5.40"
             },
             "engines": {
                 "node": ">=12"
@@ -5223,30 +5270,33 @@
             }
         },
         "node_modules/@wordpress/deprecated": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.32.0.tgz",
+            "integrity": "sha512-onQuqKH1r8G1rYQ2NSaWbXzrIG1D7n9CBol4XG3Lj55Vi82xD5ZD6jcK5GvfBTj9gsmpBWOk0Skm8LMHhxHycw==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.25.0"
+                "@wordpress/hooks": "^3.32.0"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@wordpress/dom": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.32.0.tgz",
+            "integrity": "sha512-TAY+GfO4zS6JFcPZR2Yh0EsoKkJliNURUH4fsx1eXhqTcrfCYjo0FUQUMv5IGKriq196ku1g92eJt7/yZw60/Q==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/deprecated": "^3.25.0"
+                "@wordpress/deprecated": "^3.32.0"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@wordpress/dom-ready": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.32.0.tgz",
+            "integrity": "sha512-WqM4wL9vgu2OTHCXmZm/10c4t11jSYnDijuhlHLicFQ4aJmw1q8d+PfEGUnj6wBXVzNizo8x/gvOX3aVejAxrw==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5255,13 +5305,14 @@
             }
         },
         "node_modules/@wordpress/element": {
-            "version": "5.2.0",
-            "license": "GPL-2.0-or-later",
+            "version": "5.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.9.0.tgz",
+            "integrity": "sha512-ZZB82h08Il9d45o4HrcbF3G6Q8yJU6NNyLnO/CMdfpCxD45bbwFT5drzmGx4jZniCrm+s/LoxArXLS+O8/Lx1Q==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "@types/react": "^18.0.21",
                 "@types/react-dom": "^18.0.6",
-                "@wordpress/escape-html": "^2.25.0",
+                "@wordpress/escape-html": "^2.32.0",
                 "change-case": "^4.1.2",
                 "is-plain-object": "^5.0.0",
                 "react": "^18.2.0",
@@ -5358,8 +5409,9 @@
             }
         },
         "node_modules/@wordpress/escape-html": {
-            "version": "2.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "2.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.32.0.tgz",
+            "integrity": "sha512-0GNMvutdJUhYgfIY6iAI4mNsyQV4FvMgUgECBQ1hXpWdbxGM7Lu2nH/UxLrAlh5QehNor+stYScT4v+yWJsM+g==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5434,8 +5486,9 @@
             }
         },
         "node_modules/@wordpress/hooks": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.32.0.tgz",
+            "integrity": "sha512-jYwi0MkUIrMw5RQaQFnAQS8iwxQXbipCIyK8tak1rPyAUtS0Ho8WN8I750srpg9x1XmVHrRi1j0xf8I5VbfUuA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5444,8 +5497,9 @@
             }
         },
         "node_modules/@wordpress/html-entities": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.32.0.tgz",
+            "integrity": "sha512-B1PK+F2pJM+0Ido9Ucti/yQxjssm4W6NtJTFcgZA6HJgyfBmRU54LRBCcBt6wCpJERpMn0bm9nFJqc0nvJSfNQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5454,11 +5508,12 @@
             }
         },
         "node_modules/@wordpress/i18n": {
-            "version": "4.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.32.0.tgz",
+            "integrity": "sha512-WXLmsvxWG0IAT5XBpwGROG47Q+BNWZdbR9IWi5Btz6Uh1kAya/HVbnwlT2sIB3FLeHXdFv0W2y2ideJtoflDvA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.25.0",
+                "@wordpress/hooks": "^3.32.0",
                 "gettext-parser": "^1.3.1",
                 "memize": "^1.1.0",
                 "sprintf-js": "^1.1.1",
@@ -5472,12 +5527,13 @@
             }
         },
         "node_modules/@wordpress/icons": {
-            "version": "9.16.0",
-            "license": "GPL-2.0-or-later",
+            "version": "9.23.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.23.0.tgz",
+            "integrity": "sha512-sHE7UgDX4FUuiBPg71uckXriBim/gb1hL1t2NwqVUYTVB1FzXSaJ/kQYox1u46WzbK2z5u165J/c/VrDsQ9YZA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/element": "^5.2.0",
-                "@wordpress/primitives": "^3.23.0"
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/primitives": "^3.30.0"
             },
             "engines": {
                 "node": ">=12"
@@ -5510,8 +5566,9 @@
             }
         },
         "node_modules/@wordpress/is-shallow-equal": {
-            "version": "4.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.32.0.tgz",
+            "integrity": "sha512-YsFB0BqiIcHqYDMgbpEo23jRRXwleeTLFEq+1gBvEuANN+mAo5rV7oe2EHee5w5yLKyN+xN7QU9ok5XRIJpX9g==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5808,14 +5865,68 @@
             }
         },
         "node_modules/@wordpress/keyboard-shortcuts": {
-            "version": "4.2.0",
-            "license": "GPL-2.0-or-later",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-4.9.0.tgz",
+            "integrity": "sha512-07IG61W+Ic10/hgJ5qCi8YvYz7/Z6AiDNqk3MNcf5/ZM2WQOqoeUjrBy2NUSx5k+vddEgQqUHUdvcNiwnsvjDQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/data": "^8.2.0",
-                "@wordpress/element": "^5.2.0",
-                "@wordpress/keycodes": "^3.25.0",
-                "rememo": "^4.0.0"
+                "@wordpress/data": "^9.2.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "rememo": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/compose": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.9.0.tgz",
+            "integrity": "sha512-5uWC2hzhXtrBBgVsVSO5sjEt2NjgblYpPO99pD6K8zlXni0rs60cQVGcUPmOsusbQen9vJbnfYvoXPnVAbTLRw==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/mousetrap": "^1.6.8",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "change-case": "^4.1.2",
+                "clipboard": "^2.0.8",
+                "mousetrap": "^1.6.5",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.2.0.tgz",
+            "integrity": "sha512-7LIklCC9zc9kG8zVQquniEnX0KLL8J5n7WWY/AWYLOHFnjKQR65mzF5KaMl6YX041oWsDGaKBKzLvWOm23KWlA==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/redux-routine": "^4.32.0",
+                "deepmerge": "^4.3.0",
+                "equivalent-key-map": "^0.2.2",
+                "is-plain-object": "^5.0.0",
+                "is-promise": "^4.0.0",
+                "redux": "^4.1.2",
+                "turbo-combine-reducers": "^1.0.2",
+                "use-memo-one": "^1.1.1"
             },
             "engines": {
                 "node": ">=12"
@@ -5825,13 +5936,13 @@
             }
         },
         "node_modules/@wordpress/keycodes": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.32.0.tgz",
+            "integrity": "sha512-Ks8moRk8a4lLmX1uHDcy7PX4xc+xjeu757WVvIfrUpc9W5p+RrKnHJAPhYYNSr5J2gwba8xRAjstgobgIni9FQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/i18n": "^4.25.0",
-                "change-case": "^4.1.2",
-                "lodash": "^4.17.21"
+                "@wordpress/i18n": "^4.32.0",
+                "change-case": "^4.1.2"
             },
             "engines": {
                 "node": ">=12"
@@ -5894,15 +6005,16 @@
             }
         },
         "node_modules/@wordpress/preferences": {
-            "version": "3.2.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-3.9.0.tgz",
+            "integrity": "sha512-NMSd2NPzi05jiPC7Z5NJhK5uW69MOVapnuVJdBQEgeGo9hqxa5D4bI/vP/NciOLO1M/tbh4n5IQzfTXrK97FLg==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/a11y": "^3.25.0",
-                "@wordpress/components": "^23.2.0",
-                "@wordpress/data": "^8.2.0",
-                "@wordpress/i18n": "^4.25.0",
-                "@wordpress/icons": "^9.16.0",
+                "@wordpress/a11y": "^3.32.0",
+                "@wordpress/components": "^23.9.0",
+                "@wordpress/data": "^9.2.0",
+                "@wordpress/i18n": "^4.32.0",
+                "@wordpress/icons": "^9.23.0",
                 "classnames": "^2.3.1"
             },
             "engines": {
@@ -5911,6 +6023,59 @@
             "peerDependencies": {
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/preferences/node_modules/@wordpress/compose": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.9.0.tgz",
+            "integrity": "sha512-5uWC2hzhXtrBBgVsVSO5sjEt2NjgblYpPO99pD6K8zlXni0rs60cQVGcUPmOsusbQen9vJbnfYvoXPnVAbTLRw==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/mousetrap": "^1.6.8",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "change-case": "^4.1.2",
+                "clipboard": "^2.0.8",
+                "mousetrap": "^1.6.5",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.2.0.tgz",
+            "integrity": "sha512-7LIklCC9zc9kG8zVQquniEnX0KLL8J5n7WWY/AWYLOHFnjKQR65mzF5KaMl6YX041oWsDGaKBKzLvWOm23KWlA==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/redux-routine": "^4.32.0",
+                "deepmerge": "^4.3.0",
+                "equivalent-key-map": "^0.2.2",
+                "is-plain-object": "^5.0.0",
+                "is-promise": "^4.0.0",
+                "redux": "^4.1.2",
+                "turbo-combine-reducers": "^1.0.2",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
             }
         },
         "node_modules/@wordpress/prettier-config": {
@@ -5925,11 +6090,12 @@
             }
         },
         "node_modules/@wordpress/primitives": {
-            "version": "3.23.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.30.0.tgz",
+            "integrity": "sha512-45Q0QvotCI2o+5GvtZhkgt47L96pRjhtNr0NpICcFjpVblOg1WPBqNPB03r8L4c1u9sELmnBPmn1vU3tofX7FA==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/element": "^5.2.0",
+                "@wordpress/element": "^5.9.0",
                 "classnames": "^2.3.1"
             },
             "engines": {
@@ -5937,8 +6103,9 @@
             }
         },
         "node_modules/@wordpress/priority-queue": {
-            "version": "2.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "2.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.32.0.tgz",
+            "integrity": "sha512-L8q6V/ZpNMqBgdnr4OsSJdLyvMai8Yi7noVoLZPp6bcuEOXDEQSVcPv1/R4Ch6z2/zgF80wPwf5zTkcG8ar45g==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "requestidlecallback": "^0.3.0"
@@ -5947,9 +6114,21 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@wordpress/private-apis": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.14.0.tgz",
+            "integrity": "sha512-4F5aCsjWijjq9JjAPUAh0iGnrsRoJNVgQGfOZFND7PMswuaA+uu7xtarKQ5QRsjA1owz2QOv7Hg+MvMuwmG0NA==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@wordpress/redux-routine": {
-            "version": "4.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.32.0.tgz",
+            "integrity": "sha512-7lFDphLZR+6wqWZUyxdo4azOb/7Lxn1JFT1xVPVqJpjkmEotKXEsZR16LkQz91AUzGvUTrJFVmoBIVxlW73K/Q==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "is-plain-object": "^5.0.0",
@@ -5987,20 +6166,74 @@
             }
         },
         "node_modules/@wordpress/rich-text": {
-            "version": "6.2.0",
-            "license": "GPL-2.0-or-later",
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.9.0.tgz",
+            "integrity": "sha512-ejMnW4YCW6/U8Z+9r/2ssHPkMa4HraLVQ/uiT/zU8MgwL5kiOUXX/DSIRzhhZh58031Bf18pIgxeHDQUJGIshw==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/a11y": "^3.25.0",
-                "@wordpress/compose": "^6.2.0",
-                "@wordpress/data": "^8.2.0",
-                "@wordpress/deprecated": "^3.25.0",
-                "@wordpress/element": "^5.2.0",
-                "@wordpress/escape-html": "^2.25.0",
-                "@wordpress/i18n": "^4.25.0",
-                "@wordpress/keycodes": "^3.25.0",
+                "@wordpress/a11y": "^3.32.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/data": "^9.2.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/escape-html": "^2.32.0",
+                "@wordpress/i18n": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
                 "memize": "^1.1.0",
-                "rememo": "^4.0.0"
+                "rememo": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.9.0.tgz",
+            "integrity": "sha512-5uWC2hzhXtrBBgVsVSO5sjEt2NjgblYpPO99pD6K8zlXni0rs60cQVGcUPmOsusbQen9vJbnfYvoXPnVAbTLRw==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/mousetrap": "^1.6.8",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "change-case": "^4.1.2",
+                "clipboard": "^2.0.8",
+                "mousetrap": "^1.6.5",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.2.0.tgz",
+            "integrity": "sha512-7LIklCC9zc9kG8zVQquniEnX0KLL8J5n7WWY/AWYLOHFnjKQR65mzF5KaMl6YX041oWsDGaKBKzLvWOm23KWlA==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/redux-routine": "^4.32.0",
+                "deepmerge": "^4.3.0",
+                "equivalent-key-map": "^0.2.2",
+                "is-plain-object": "^5.0.0",
+                "is-promise": "^4.0.0",
+                "redux": "^4.1.2",
+                "turbo-combine-reducers": "^1.0.2",
+                "use-memo-one": "^1.1.1"
             },
             "engines": {
                 "node": ">=12"
@@ -7066,8 +7299,9 @@
             }
         },
         "node_modules/@wordpress/shortcode": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.32.0.tgz",
+            "integrity": "sha512-kgAaeCdwgtPjVPqFfdllCxPn1DJYVCrnLsW7tGPEb9zAeGdBo6SSdlSnc/jkExshXh5VEOhh/SNUB/OhoNhesg==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "memize": "^1.1.0"
@@ -7077,8 +7311,9 @@
             }
         },
         "node_modules/@wordpress/style-engine": {
-            "version": "1.8.0",
-            "license": "GPL-2.0-or-later",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.15.0.tgz",
+            "integrity": "sha512-axWOvO0CfHWQ6JnursjHs1djQ9wpylFBGw/EMFf06KrqiOQ8wvH4WcNGiSpA35Q8npS2ajg1fbuSSinHwD6gTw==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "lodash": "^4.17.21"
@@ -7103,8 +7338,9 @@
             }
         },
         "node_modules/@wordpress/token-list": {
-            "version": "2.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "2.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.32.0.tgz",
+            "integrity": "sha512-Z/otEb6OOJtH6+kawnrkkxW8WzoY5JfC1/A1/LK25uSyR2Kln5vI9YRUEdsxVX+8S8atzyDfnHFGsVFQFJCcJQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -7113,8 +7349,9 @@
             }
         },
         "node_modules/@wordpress/url": {
-            "version": "3.26.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.33.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.33.0.tgz",
+            "integrity": "sha512-J9VPIK72NOYE4xpvd+HT8KLLDh37Ao8Y+f02eqa4DHW79BsRHjZ1pXKiK7KKVPXA6MkP44gXF8OliKbWBphsUg==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
                 "remove-accents": "^0.4.2"
@@ -7139,15 +7376,17 @@
             }
         },
         "node_modules/@wordpress/warning": {
-            "version": "2.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "2.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.32.0.tgz",
+            "integrity": "sha512-jGzeFcThz/7jwWezu1pLtHLQap5aDmpF3v2bXXKJBA5Qb4VIRD4oauf1yFvqqb9CkfTLhw8E/KbtW0xzVffqDg==",
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@wordpress/wordcount": {
-            "version": "3.25.0",
-            "license": "GPL-2.0-or-later",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.32.0.tgz",
+            "integrity": "sha512-CYlOoT/0ZR7DoKzNFUZ1UnTimql6Y6kOMZbz6RUFLGCoTSp8/BeLVpfboohWAkCFEnMOjbrpOgl4f+wt8qmV8g==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -9901,8 +10140,9 @@
             "license": "MIT"
         },
         "node_modules/deepmerge": {
-            "version": "4.2.2",
-            "license": "MIT",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12185,12 +12425,11 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "7.10.3",
-            "license": "MIT",
+            "version": "10.12.9",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.9.tgz",
+            "integrity": "sha512-diLij2xjOn8RS1xz66wNDTa6nezR3bRRBB9J0r1a5xeJjcSdJpOkk2U7pTzhg1v54bzZ7HBLJ4gKo8aAQM0U3w==",
             "dependencies": {
-                "@motionone/dom": "^10.15.3",
-                "hey-listen": "^1.0.8",
-                "tslib": "2.4.0"
+                "tslib": "^2.4.0"
             },
             "optionalDependencies": {
                 "@emotion/is-prop-valid": "^0.8.2"
@@ -12198,11 +12437,20 @@
             "peerDependencies": {
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
             "version": "0.8.8",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+            "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
             "optional": true,
             "dependencies": {
                 "@emotion/memoize": "0.7.4"
@@ -12210,12 +12458,9 @@
         },
         "node_modules/framer-motion/node_modules/@emotion/memoize": {
             "version": "0.7.4",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+            "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
             "optional": true
-        },
-        "node_modules/framer-motion/node_modules/tslib": {
-            "version": "2.4.0",
-            "license": "0BSD"
         },
         "node_modules/fresh": {
             "version": "0.5.2",
@@ -12762,10 +13007,6 @@
         "node_modules/hex-color-regex": {
             "version": "1.1.0",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/hey-listen": {
-            "version": "1.0.8",
             "license": "MIT"
         },
         "node_modules/hi-base32": {
@@ -20304,8 +20545,9 @@
             }
         },
         "node_modules/proxy-compare": {
-            "version": "2.4.0",
-            "license": "MIT"
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+            "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
@@ -23911,20 +24153,41 @@
             }
         },
         "node_modules/valtio": {
-            "version": "1.9.0",
-            "license": "MIT",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.7.0.tgz",
+            "integrity": "sha512-3Tnix66EERwMcrl1rfB3ylcewOcL5L/GiPmC3FlVNreQzqf2jufEeqlNmgnLgSGchkEmH3WYVtS+x6Qw4r+yzQ==",
             "dependencies": {
-                "proxy-compare": "2.4.0",
+                "proxy-compare": "2.3.0",
                 "use-sync-external-store": "1.2.0"
             },
             "engines": {
-                "node": ">=12.20.0"
+                "node": ">=12.7.0"
             },
             "peerDependencies": {
-                "react": ">=16.8"
+                "@babel/helper-module-imports": ">=7.12",
+                "@babel/types": ">=7.13",
+                "aslemammad-vite-plugin-macro": ">=1.0.0-alpha.1",
+                "babel-plugin-macros": ">=3.0",
+                "react": ">=16.8",
+                "vite": ">=2.8.6"
             },
             "peerDependenciesMeta": {
+                "@babel/helper-module-imports": {
+                    "optional": true
+                },
+                "@babel/types": {
+                    "optional": true
+                },
+                "aslemammad-vite-plugin-macro": {
+                    "optional": true
+                },
+                "babel-plugin-macros": {
+                    "optional": true
+                },
                 "react": {
+                    "optional": true
+                },
+                "vite": {
                     "optional": true
                 }
             }
@@ -25786,7 +26049,7 @@
         "packages/form-builder": {
             "name": "@givewp/form-builder",
             "dependencies": {
-                "@wordpress/block-editor": "^11.2.0",
+                "@wordpress/block-editor": "^12.0.0",
                 "@wordpress/block-library": "^8.2.0",
                 "@wordpress/blocks": "^12.2.0",
                 "@wordpress/components": "^23.2.0",
@@ -25815,6 +26078,130 @@
                 "jest": "^29.3.1",
                 "laravel-mix": "^6.0.49",
                 "ts-node": "^10.9.1"
+            }
+        },
+        "packages/form-builder/node_modules/@wordpress/block-editor": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.0.0.tgz",
+            "integrity": "sha512-uMndH9W0tXFRBiX8Y07aGpZnAT17lIjxa5PBgS9LhxenPICaKZxFMrCCCBczTUjdGv51b5FYc9FJN977LFz95Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@react-spring/web": "^9.4.5",
+                "@wordpress/a11y": "^3.32.0",
+                "@wordpress/api-fetch": "^6.29.0",
+                "@wordpress/blob": "^3.32.0",
+                "@wordpress/blocks": "^12.9.0",
+                "@wordpress/components": "^23.9.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/data": "^9.2.0",
+                "@wordpress/date": "^4.32.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/escape-html": "^2.32.0",
+                "@wordpress/hooks": "^3.32.0",
+                "@wordpress/html-entities": "^3.32.0",
+                "@wordpress/i18n": "^4.32.0",
+                "@wordpress/icons": "^9.23.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keyboard-shortcuts": "^4.9.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/notices": "^4.0.0",
+                "@wordpress/preferences": "^3.9.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/rich-text": "^6.9.0",
+                "@wordpress/shortcode": "^3.32.0",
+                "@wordpress/style-engine": "^1.15.0",
+                "@wordpress/token-list": "^2.32.0",
+                "@wordpress/url": "^3.33.0",
+                "@wordpress/warning": "^2.32.0",
+                "@wordpress/wordcount": "^3.32.0",
+                "change-case": "^4.1.2",
+                "classnames": "^2.3.1",
+                "colord": "^2.7.0",
+                "diff": "^4.0.2",
+                "dom-scroll-into-view": "^1.2.1",
+                "fast-deep-equal": "^3.1.3",
+                "inherits": "^2.0.3",
+                "lodash": "^4.17.21",
+                "react-autosize-textarea": "^7.1.0",
+                "react-easy-crop": "^4.5.1",
+                "rememo": "^4.0.2",
+                "remove-accents": "^0.4.2",
+                "traverse": "^0.6.6"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0",
+                "react-dom": "^18.0.0"
+            }
+        },
+        "packages/form-builder/node_modules/@wordpress/compose": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.9.0.tgz",
+            "integrity": "sha512-5uWC2hzhXtrBBgVsVSO5sjEt2NjgblYpPO99pD6K8zlXni0rs60cQVGcUPmOsusbQen9vJbnfYvoXPnVAbTLRw==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@types/mousetrap": "^1.6.8",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/dom": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/keycodes": "^3.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "change-case": "^4.1.2",
+                "clipboard": "^2.0.8",
+                "mousetrap": "^1.6.5",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "packages/form-builder/node_modules/@wordpress/data": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.2.0.tgz",
+            "integrity": "sha512-7LIklCC9zc9kG8zVQquniEnX0KLL8J5n7WWY/AWYLOHFnjKQR65mzF5KaMl6YX041oWsDGaKBKzLvWOm23KWlA==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/compose": "^6.9.0",
+                "@wordpress/deprecated": "^3.32.0",
+                "@wordpress/element": "^5.9.0",
+                "@wordpress/is-shallow-equal": "^4.32.0",
+                "@wordpress/priority-queue": "^2.32.0",
+                "@wordpress/private-apis": "^0.14.0",
+                "@wordpress/redux-routine": "^4.32.0",
+                "deepmerge": "^4.3.0",
+                "equivalent-key-map": "^0.2.2",
+                "is-plain-object": "^5.0.0",
+                "is-promise": "^4.0.0",
+                "redux": "^4.1.2",
+                "turbo-combine-reducers": "^1.0.2",
+                "use-memo-one": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0"
+            }
+        },
+        "packages/form-builder/node_modules/@wordpress/notices": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.0.0.tgz",
+            "integrity": "sha512-PFYF7q6sF3EjCItRw1CngXthtD6J4LGbc6pVfQt6TLZfiVgNdebgktlu2sXWglSATfA+/FlDv60tdpRaN2rRHg==",
+            "dependencies": {
+                "@babel/runtime": "^7.16.0",
+                "@wordpress/a11y": "^3.32.0",
+                "@wordpress/data": "^9.2.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         }
     }

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -8,7 +8,7 @@
         "test": "jest"
     },
     "dependencies": {
-        "@wordpress/block-editor": "^11.2.0",
+        "@wordpress/block-editor": "^12.0.0",
         "@wordpress/block-library": "^8.2.0",
         "@wordpress/blocks": "^12.2.0",
         "@wordpress/components": "^23.2.0",

--- a/packages/form-builder/src/App.scss
+++ b/packages/form-builder/src/App.scss
@@ -527,3 +527,7 @@ This creates a consistent separator between the tabs and the rest of the sidebar
 .give-billing-period-control .components-radio-control__input[type='radio']:checked + label {
     border-color: black;
 }
+
+.block-editor-inserter__main-area {
+    width: 100%;
+}

--- a/packages/form-builder/src/blocks/fields/amount/inspector/add-button.tsx
+++ b/packages/form-builder/src/blocks/fields/amount/inspector/add-button.tsx
@@ -1,9 +1,8 @@
 import {Button} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {SVGProps} from 'react';
-import ButtonProps = Button.ButtonProps;
 
-const AddButton = (props: ButtonProps) => {
+const AddButton = (props) => {
     return (
         <Button {...props} variant={'secondary'} style={{width: '100%', justifyContent: 'center'}} icon={PlusIcon}>
             {__('Add another level', 'give')}

--- a/packages/form-builder/src/blocks/section/settings.tsx
+++ b/packages/form-builder/src/blocks/section/settings.tsx
@@ -5,7 +5,7 @@ import Edit from './Edit';
 
 const settings: SectionBlock['settings'] = {
     title: __('Section', 'give'),
-    category: 'layout',
+    category: 'section',
     description: __('A section groups form fields and content together.', 'give'),
     icon: () => (
         <Icon

--- a/packages/form-builder/src/components/forks/BlockCard.tsx
+++ b/packages/form-builder/src/components/forks/BlockCard.tsx
@@ -18,9 +18,11 @@ import BlockIcon from './BlockIcon';
 import {store as blockEditorStore} from '@wordpress/block-editor';
 
 function BlockCard({title, icon, description, className = ''}) {
+    // @ts-ignore
     const isOffCanvasNavigationEditorEnabled = window?.__experimentalEnableOffCanvasNavigationEditor === true;
 
     const {parentNavBlockClientId} = useSelect((select) => {
+        // @ts-ignore
         const {getSelectedBlockClientId, getBlockParentsByBlockName} = select(blockEditorStore);
 
         const _selectedBlockClientId = getSelectedBlockClientId();
@@ -47,6 +49,7 @@ function BlockCard({title, icon, description, className = ''}) {
                     isSmall
                 />
             )}
+            {/*@ts-ignore*/}
             <BlockIcon icon={icon} showColors />
             <div className="block-editor-block-card__content">
                 <h2 className="block-editor-block-card__title">{title}</h2>

--- a/packages/form-builder/src/components/forks/BlockCard.tsx
+++ b/packages/form-builder/src/components/forks/BlockCard.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {Button} from '@wordpress/components';
+import {chevronLeft, chevronRight} from '@wordpress/icons';
+import {__, isRTL} from '@wordpress/i18n';
+import {useDispatch, useSelect} from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from './BlockIcon';
+import {store as blockEditorStore} from '@wordpress/block-editor';
+
+function BlockCard({title, icon, description, className = ''}) {
+    const isOffCanvasNavigationEditorEnabled = window?.__experimentalEnableOffCanvasNavigationEditor === true;
+
+    const {parentNavBlockClientId} = useSelect((select) => {
+        const {getSelectedBlockClientId, getBlockParentsByBlockName} = select(blockEditorStore);
+
+        const _selectedBlockClientId = getSelectedBlockClientId();
+
+        return {
+            parentNavBlockClientId: getBlockParentsByBlockName(_selectedBlockClientId, 'core/navigation', true)[0],
+        };
+    }, []);
+
+    const {selectBlock} = useDispatch(blockEditorStore);
+
+    return (
+        <div className={classnames('block-editor-block-card', className)}>
+            {isOffCanvasNavigationEditorEnabled && parentNavBlockClientId && (
+                <Button
+                    onClick={() => selectBlock(parentNavBlockClientId)}
+                    label={__('Go to parent Navigation block')}
+                    style={
+                        // TODO: This style override is also used in ToolsPanelHeader.
+                        // It should be supported out-of-the-box by Button.
+                        {minWidth: 24, padding: 0}
+                    }
+                    icon={isRTL() ? chevronRight : chevronLeft}
+                    isSmall
+                />
+            )}
+            <BlockIcon icon={icon} showColors />
+            <div className="block-editor-block-card__content">
+                <h2 className="block-editor-block-card__title">{title}</h2>
+                <span className="block-editor-block-card__description">{description}</span>
+            </div>
+        </div>
+    );
+}
+
+export default BlockCard;

--- a/packages/form-builder/src/components/forks/BlockIcon.tsx
+++ b/packages/form-builder/src/components/forks/BlockIcon.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {Icon} from '@wordpress/components';
+import {blockDefault} from '@wordpress/icons';
+import {memo} from '@wordpress/element';
+
+function BlockIcon({icon, showColors = false, className, context}) {
+    if (icon?.src === 'block-default') {
+        icon = {
+            src: blockDefault,
+        };
+    }
+
+    const renderedIcon = <Icon icon={icon && icon.src ? icon.src : icon} context={context} />;
+    const style = showColors
+        ? {
+              backgroundColor: icon && icon.background,
+              color: icon && icon.foreground,
+          }
+        : {};
+
+    return (
+        <span
+            style={style}
+            className={classnames('block-editor-block-icon', className, {
+                'has-colors': showColors,
+            })}
+        >
+            {renderedIcon}
+        </span>
+    );
+}
+
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-icon/README.md
+ */
+export default memo( BlockIcon );

--- a/packages/form-builder/src/components/forks/BlockIcon.tsx
+++ b/packages/form-builder/src/components/forks/BlockIcon.tsx
@@ -17,6 +17,7 @@ function BlockIcon({icon, showColors = false, className, context}) {
         };
     }
 
+    // @ts-ignore
     const renderedIcon = <Icon icon={icon && icon.src ? icon.src : icon} context={context} />;
     const style = showColors
         ? {

--- a/packages/form-builder/src/components/forks/BlockTypesList.tsx
+++ b/packages/form-builder/src/components/forks/BlockTypesList.tsx
@@ -11,8 +11,8 @@
  /**
  * Internal @wordpress dependencies
  */
-import InserterListItem from '@wordpress/block-editor/build/components/inserter-list-item';
-import {InserterListboxGroup, InserterListboxRow} from '@wordpress/block-editor/build/components/inserter-listbox';
+import InserterListItem from '@wordpress/block-editor/src/components/inserter-list-item';
+import {InserterListboxGroup, InserterListboxRow} from '@wordpress/block-editor/src/components/inserter-listbox';
 
 import {getBlockMenuDefaultClassName} from '@wordpress/blocks';
 

--- a/packages/form-builder/src/components/sidebar/Primary/index.tsx
+++ b/packages/form-builder/src/components/sidebar/Primary/index.tsx
@@ -13,7 +13,7 @@ import {
 import {PopoutSlot} from '../popout';
 import {useEffect} from 'react';
 import useSelectedBlocks from '../../../hooks/useSelectedBlocks';
-import BlockCard from '@wordpress/block-editor/build/components/block-card';
+import BlockCard from '../../forks/BlockCard';
 import {brush, settings} from '@wordpress/icons';
 
 const {Slot: InspectorSlot, Fill: InspectorFill} = createSlotFill('StandAloneBlockEditorSidebarInspector');

--- a/packages/form-builder/src/components/sidebar/Secondary.tsx
+++ b/packages/form-builder/src/components/sidebar/Secondary.tsx
@@ -1,5 +1,4 @@
 import {__} from '@wordpress/i18n';
-//import FieldTypesList from './panels/FieldTypesList';
 import BlockListTree from './panels/BlockListTree';
 import {__experimentalLibrary as Library} from '@wordpress/block-editor';
 

--- a/packages/form-builder/src/components/sidebar/Secondary.tsx
+++ b/packages/form-builder/src/components/sidebar/Secondary.tsx
@@ -1,15 +1,19 @@
 import {__} from '@wordpress/i18n';
-import FieldTypesList from './panels/FieldTypesList';
+//import FieldTypesList from './panels/FieldTypesList';
 import BlockListTree from './panels/BlockListTree';
+import {__experimentalLibrary as Library} from '@wordpress/block-editor';
+
+const BlockListInserter = () => {
+    return <Library showInserterHelpPanel={false} />;
+};
 
 type PropTypes = {
     selected: string;
 };
 
 const Sidebar = ({selected}: PropTypes) => {
-
     const panels = {
-        add: FieldTypesList,
+        add: BlockListInserter,
         list: BlockListTree,
     };
 
@@ -28,6 +32,6 @@ const Sidebar = ({selected}: PropTypes) => {
             <PanelContent />
         </div>
     );
-}
+};
 
 export default Sidebar;

--- a/packages/form-builder/src/components/sidebar/panels/FieldTypesList.tsx
+++ b/packages/form-builder/src/components/sidebar/panels/FieldTypesList.tsx
@@ -1,5 +1,5 @@
 import {useSelect} from '@wordpress/data';
-import {store as blockEditorStore} from '@wordpress/block-editor/build/store';
+import {store as blockEditorStore} from '@wordpress/block-editor';
 import {__} from '@wordpress/i18n';
 // @ts-ignore
 import {SearchControl} from '@wordpress/components';

--- a/packages/form-builder/src/components/sidebar/popout/index.tsx
+++ b/packages/form-builder/src/components/sidebar/popout/index.tsx
@@ -8,6 +8,7 @@ export default function Popout({children}) {
     );
 }
 
+// @ts-ignore
 export const PopoutSlot = () => <Slot name="InspectorPopout" />;
 
 export const PopoutContainer = ({children}) => <div

--- a/packages/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/packages/form-builder/src/containers/BlockEditorContainer.tsx
@@ -20,13 +20,14 @@ export default function BlockEditorContainer() {
 
     return (
         <BlockEditorProvider value={blocks} onInput={dispatchFormBlocks} onChange={dispatchFormBlocks}>
-            <Onboarding/>
+            <Onboarding />
             <SlotFillProvider>
                 <Sidebar.InspectorFill>
-                    <BlockInspector/>
+                    <BlockInspector />
                 </Sidebar.InspectorFill>
-                <BlockEditorInterfaceSkeletonContainer/>
-                <Popover.Slot/>
+                <BlockEditorInterfaceSkeletonContainer />
+                {/*@ts-ignore*/}
+                <Popover.Slot />
             </SlotFillProvider>
         </BlockEditorProvider>
     );

--- a/packages/form-builder/src/containers/HeaderContainer.tsx
+++ b/packages/form-builder/src/containers/HeaderContainer.tsx
@@ -1,15 +1,14 @@
-import React, {useContext, useState} from 'react';
+import React, {useState} from 'react';
 import {GiveIcon} from '../components/icons';
-import {close, cog, Icon, listView, plus, moreVertical, drawerRight} from '@wordpress/icons';
+import {drawerRight, listView, moreVertical, plus} from '@wordpress/icons';
 import {setFormSettings, useFormState, useFormStateDispatch} from '../stores/form-state';
 import {RichText} from '@wordpress/block-editor';
-import {Button, ExternalLink, TextControl, Dropdown, DropdownMenu, MenuGroup, MenuItem} from '@wordpress/components';
+import {Button, Dropdown, MenuGroup, MenuItem} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {Header} from '../components';
 import {Storage} from '../common';
 import {FormSettings, FormStatus} from '@givewp/form-builder/types';
 import {setIsDirty} from '@givewp/form-builder/stores/form-state/reducer';
-import {ShepherdTourContext} from "react-shepherd";
 
 const Logo = () => (
     <div
@@ -66,10 +65,13 @@ const HeaderContainer = ({
             contentLeft={
                 <>
                     <Logo />
-                    <div id="AddBlockButtonContainer" style={{
-                        padding: 'var(--givewp-spacing-2)',
-                        margin: 'calc(var(--givewp-spacing-2) * -1)',
-                    }}>
+                    <div
+                        id="AddBlockButtonContainer"
+                        style={{
+                            padding: 'var(--givewp-spacing-2)',
+                            margin: 'calc(var(--givewp-spacing-2) * -1)',
+                        }}
+                    >
                         <Button
                             style={{width: '32px', height: '32px', minWidth: '32px'}}
                             className="rotate-icon"
@@ -106,9 +108,8 @@ const HeaderContainer = ({
                         {isSaving && 'draft' === isSaving
                             ? __('Saving...', 'give')
                             : 'draft' === formSettings.formStatus
-                                ? __('Save as Draft', 'give')
-                                : __('Switch to Draft', 'give')
-                        }
+                            ? __('Save as Draft', 'give')
+                            : __('Switch to Draft', 'give')}
                     </Button>
                     <Button
                         onClick={() => onSave('publish')}
@@ -119,31 +120,25 @@ const HeaderContainer = ({
                         {isSaving && 'publish' === isSaving
                             ? __('Updating...', 'give')
                             : 'publish' === formSettings.formStatus
-                                ? __('Update', 'give')
-                                : __('Publish', 'give')
-                        }
+                            ? __('Update', 'give')
+                            : __('Publish', 'give')}
                     </Button>
                     <Button onClick={toggleShowSidebar} isPressed={showSidebar} icon={drawerRight} />
                     <Dropdown
+                        popoverProps={{placement: 'bottom-start'}}
                         // @ts-ignore
-                        popoverProps={ { placement: 'bottom-start' } }
-                        focusOnMount={"container"}
-                        renderToggle={ ( { isOpen, onToggle } ) => (
-                            <Button
-                                onClick={onToggle}
-                                icon={moreVertical}
-                            />
-                        ) }
-                        renderContent={ ({onClose}) => (
+                        focusOnMount={'container'}
+                        renderToggle={({isOpen, onToggle}) => <Button onClick={onToggle} icon={moreVertical} />}
+                        renderContent={({onClose}) => (
                             <div style={{minWidth: '280px', maxWidth: '400px'}}>
                                 <MenuGroup label={__('Tools', 'give')}>
                                     <MenuItem
                                         onClick={() => {
                                             // @ts-ignore
-                                            if(!window.tour.isActive()) {
+                                            if (!window.tour.isActive()) {
                                                 // @ts-ignore
-                                                window.tour.start()
-                                                onClose()
+                                                window.tour.start();
+                                                onClose();
                                             }
                                         }}
                                     >

--- a/packages/form-builder/src/feedback/index.tsx
+++ b/packages/form-builder/src/feedback/index.tsx
@@ -21,6 +21,7 @@ const Feedback = () => {
         setHidden(!!localStorage.getItem(HIDE_FEEDBACK));
     }, []);
 
+    // @ts-ignore
     return (
         <Container>
             {!hidden && (
@@ -38,7 +39,6 @@ const Feedback = () => {
                         <div>
                             <ExternalLink
                                 href={feedbackUrl}
-                                target="_blank"
                                 rel="noopener noreferrer"
                                 onClick={closeCallback}
                                 style={{color: 'var(--givewp-primary-600)'}}

--- a/packages/form-builder/src/hooks/useSelectedBlocks.js
+++ b/packages/form-builder/src/hooks/useSelectedBlocks.js
@@ -1,19 +1,15 @@
-import {useSelect} from "@wordpress/data";
-import {store as blockEditorStore} from "@wordpress/block-editor/build/store";
+import {useSelect} from '@wordpress/data';
+import {store as blockEditorStore} from '@wordpress/block-editor';
 
 const useSelectedBlocks = () => {
-    const {
-        selectedBlocks,
-    } = useSelect(select => {
-        const {
-            getSelectedBlockClientIds,
-        } = select(blockEditorStore);
+    const {selectedBlocks} = useSelect((select) => {
+        const {getSelectedBlockClientIds} = select(blockEditorStore);
         return {
             selectedBlocks: getSelectedBlockClientIds(),
         };
     });
 
-    return selectedBlocks
+    return selectedBlocks;
 };
 
 export default useSelectedBlocks;

--- a/packages/form-builder/src/index.tsx
+++ b/packages/form-builder/src/index.tsx
@@ -1,5 +1,5 @@
 import React, {createRoot, render} from '@wordpress/element';
-import {BlockSupports, registerBlockType} from '@wordpress/blocks';
+import {BlockSupports, registerBlockType, setCategories} from '@wordpress/blocks';
 
 import App from './App';
 
@@ -7,11 +7,31 @@ import sectionBlocks, {sectionBlockNames} from './blocks/section';
 import fieldBlocks from './blocks/fields';
 import elementBlocks from './blocks/elements';
 import {FieldBlock} from '@givewp/form-builder/types';
+import {__} from '@wordpress/i18n';
 
 const supportOverrides: BlockSupports = {
     customClassName: false,
     html: false,
 };
+
+setCategories([
+    {
+        slug: 'input',
+        title: __('Input Fields', 'give'),
+    },
+    {
+        slug: 'content',
+        title: __('Content & Media', 'give'),
+    },
+    {
+        slug: 'section',
+        title: __('Sections', 'give'),
+    },
+    {
+        slug: 'custom',
+        title: __('Custom Fields', 'give'),
+    },
+]);
 
 sectionBlocks.map(({name, settings}: FieldBlock) =>
     registerBlockType(name, {

--- a/packages/form-builder/src/index.tsx
+++ b/packages/form-builder/src/index.tsx
@@ -24,8 +24,9 @@ setCategories([
         title: __('Content & Media', 'give'),
     },
     {
+        // layout seems to be a core category slug
         slug: 'section',
-        title: __('Sections', 'give'),
+        title: __('Layout', 'give'),
     },
     {
         slug: 'custom',

--- a/packages/form-builder/src/index.tsx
+++ b/packages/form-builder/src/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import {createRoot} from 'react-dom/client';
+import React, {createRoot, render} from '@wordpress/element';
 import {BlockSupports, registerBlockType} from '@wordpress/blocks';
 
 import App from './App';
@@ -35,11 +34,15 @@ sectionBlocks.map(({name, settings}: FieldBlock) =>
     })
 );
 
-const container = document.getElementById('root');
-const root = createRoot(container!);
+const root = document.getElementById('root');
 
-root.render(
-    <React.StrictMode>
-        <App/>
-    </React.StrictMode>
-);
+if (createRoot) {
+    createRoot(root).render(<App />);
+} else {
+    render(
+        <React.StrictMode>
+            <App />
+        </React.StrictMode>,
+        root
+    );
+}

--- a/packages/form-builder/src/index.tsx
+++ b/packages/form-builder/src/index.tsx
@@ -1,5 +1,5 @@
 import React, {createRoot, render} from '@wordpress/element';
-import {BlockSupports, registerBlockType, setCategories} from '@wordpress/blocks';
+import {BlockSupports, getCategories, registerBlockType, setCategories} from '@wordpress/blocks';
 
 import App from './App';
 
@@ -15,6 +15,7 @@ const supportOverrides: BlockSupports = {
 };
 
 setCategories([
+    ...getCategories(),
     {
         slug: 'input',
         title: __('Input Fields', 'give'),

--- a/packages/form-builder/src/settings/offline-donation/donation-instructions.js
+++ b/packages/form-builder/src/settings/offline-donation/donation-instructions.js
@@ -1,11 +1,10 @@
-import {useState} from "react";
-import {useToggleState} from "../../hooks";
-import {Button} from "@wordpress/components";
-import Popout, {PopoutContainer} from "../../components/sidebar/popout";
-import {RichText} from "@wordpress/block-editor/build/components";
+import {useState} from 'react';
+import {useToggleState} from '../../hooks';
+import {Button} from '@wordpress/components';
+import Popout, {PopoutContainer} from '../../components/sidebar/popout';
+import {RichText} from '@wordpress/block-editor';
 
 const DonationInstructions = () => {
-
     const {state: showPopout, toggle: toggleShowPopout} = useToggleState();
 
     const [content, setContent] = useState(`
@@ -16,19 +15,30 @@ const DonationInstructions = () => {
 
     return (
         <>
-            <div style={{
-                marginTop: '10px',
-                width: '100%',
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-            }}>
+            <div
+                style={{
+                    marginTop: '10px',
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                }}
+            >
                 Donation Instructions
                 <Button onClick={toggleShowPopout} style={{color: 'white', backgroundColor: '#68BF6B'}}>
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24"
-                         stroke="currentColor" strokeWidth="2">
-                        <path strokeLinecap="round" strokeLinejoin="round"
-                              d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-6 w-6"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+                        />
                     </svg>
                 </Button>
             </div>
@@ -55,22 +65,26 @@ const DonationInstructions = () => {
                                     placeholder={'PLACEHOLDER TEXT'}
                                 />
                             </div>
-                            <div style={{
-                                display: 'flex',
-                                gap: '20px',
-                                padding: '10px',
-                                borderBottom: '1px solid lightgray',
-                            }}>
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    gap: '20px',
+                                    padding: '10px',
+                                    borderBottom: '1px solid lightgray',
+                                }}
+                            >
                                 <span>Visual</span>
                                 <span>Text</span>
                             </div>
-                            <div style={{
-                                display: 'flex',
-                                flexDirection: 'column',
-                                gap: '20px',
-                                padding: '15px 10px',
-                                borderBottom: '1px solid lightgray',
-                            }}>
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    gap: '20px',
+                                    padding: '15px 10px',
+                                    borderBottom: '1px solid lightgray',
+                                }}
+                            >
                                 <div>Text Style</div>
                                 <div>Text Format</div>
                                 <div>Alignment</div>
@@ -80,7 +94,8 @@ const DonationInstructions = () => {
                         </div>
                     </PopoutContainer>
                 </Popout>
-            )}</>
+            )}
+        </>
     );
 };
 

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -18,6 +18,7 @@ class RegisterFormBuilderPageRoute
     /**
      * Use add_submenu_page to register page within WP admin
      *
+     * @unreleased enqueue form builder styles
      * @since 0.1.0
      *
      * @return void
@@ -42,7 +43,6 @@ class RegisterFormBuilderPageRoute
 
         add_action("admin_print_styles", static function () {
             if (FormBuilderRouteBuilder::isRoute()) {
-                //wp_enqueue_style('wp-edit-blocks');
                 wp_enqueue_style(
                     '@givewp/form-builder/style-wordpress',
                     GIVE_NEXT_GEN_URL . 'build/style-formBuilderApp.css'
@@ -63,6 +63,7 @@ class RegisterFormBuilderPageRoute
     /**
      * Render page with scripts
      *
+     * @unreleased enqueue form builder scripts from plugin root
      * @since 0.1.0
      *
      * @return void

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -5,10 +5,8 @@ use Give\Addon\View;
 use Give\FormBuilder\FormBuilderRouteBuilder;
 use Give\FormBuilder\ViewModels\FormBuilderViewModel;
 use Give\Framework\EnqueueScript;
-
 use Give\Framework\PaymentGateways\Contracts\NextGenPaymentGatewayInterface;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
-use Give\NextGen\DonationForm\Repositories\DonationFormRepository;
 
 use function wp_enqueue_style;
 
@@ -44,6 +42,16 @@ class RegisterFormBuilderPageRoute
 
         add_action("admin_print_styles", static function () {
             if (FormBuilderRouteBuilder::isRoute()) {
+                //wp_enqueue_style('wp-edit-blocks');
+                wp_enqueue_style(
+                    '@givewp/form-builder/style-wordpress',
+                    GIVE_NEXT_GEN_URL . 'build/style-formBuilderApp.css'
+                );
+                wp_enqueue_style(
+                    '@givewp/form-builder/style-app',
+                    GIVE_NEXT_GEN_URL . 'build/formBuilderApp.css'
+                );
+
                 wp_enqueue_style(
                     'givewp-form-builder-admin-styles',
                     GIVE_NEXT_GEN_URL . 'src/FormBuilder/resources/css/admin-form-builder.css'
@@ -107,7 +115,7 @@ class RegisterFormBuilderPageRoute
 
         (new EnqueueScript(
             '@givewp/form-builder/script',
-            $formBuilderViewModel->jsPathFromRoot(),
+            $formBuilderViewModel->jsPathFromPluginRoot(),
             GIVE_NEXT_GEN_DIR,
             GIVE_NEXT_GEN_URL,
             'give'
@@ -122,7 +130,7 @@ class RegisterFormBuilderPageRoute
             ])
             ->enqueue();
 
-        wp_localize_script( '@givewp/form-builder/script', 'onboardingTourData', [
+        wp_localize_script('@givewp/form-builder/script', 'onboardingTourData', [
             'actionUrl' => admin_url('admin-ajax.php?action=givewp_tour_completed'),
             'autoStartTour' => !get_user_meta(get_current_user_id(), 'givewp-form-builder-tour-completed', true),
         ]);

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -49,4 +49,12 @@ class FormBuilderViewModel
     {
         return 'packages/form-builder/build/givewp-form-builder.js';
     }
+
+    /**
+     * @unreleased
+     */
+    public function jsPathFromPluginRoot(): string
+    {
+        return 'build/formBuilderApp.js';
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = {
             '@givewp/forms/types': path.resolve(__dirname, 'src/NextGen/DonationForm/resources/types.ts'),
             '@givewp/forms/propTypes': path.resolve(__dirname, 'src/NextGen/DonationForm/resources/propTypes.ts'),
             '@givewp/forms/app': path.resolve(__dirname, 'src/NextGen/DonationForm/resources/app'),
+            '@givewp/form-builder': path.resolve(__dirname, 'packages/form-builder/src'),
         },
     },
     entry: {
@@ -43,6 +44,7 @@ module.exports = {
             'NextGen/DonationForm/resources/receipt/DonationConfirmationReceiptApp.tsx'
         ),
         baseFormDesignCss: srcPath('NextGen/DonationForm/resources/styles/base.scss'),
+        formBuilderApp: path.resolve(process.cwd(), 'packages/form-builder/src/index.tsx'),
     },
 };
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the form builder build process to use wp-scripts when loaded from the plugin.  This is necessary to offload dependency management to WordPress for use with custom external blocks.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form builder will not use the WordPress installation to load dependencies / gutenberg scripts.  Some imports that were coming directly from a package that is not publicly exposed were relocated and/or forked.

The main noticeable difference here is the secondary sidebar / block inserter.  It was too much of a rabbit hole to fork the components we were using so it is now simplified with the `<Library />` component that WP core and the isolated editor are using.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1440" alt="Screenshot 2023-05-10 at 11 56 50 AM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/1ad34248-5056-413f-91c9-002190ff7ae8">

<img width="1440" alt="Screenshot 2023-05-10 at 11 10 12 AM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/9bb674d5-29aa-4a32-845c-de872aea8ace">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Pull branch and run `npm install && npm run build'
- Open or create a next gen form and use the builder
- Everything should work the same except the block inserter/secondary sidebar which only shows child blocks when cursor is selecting section inner blocks in canvas.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

