### PR TITLE
Feature: add showHeader setting

### DIFF
--- a/packages/form-builder/src/settings/design/index.tsx
+++ b/packages/form-builder/src/settings/design/index.tsx
@@ -1,10 +1,9 @@
 import {PanelBody, PanelRow, SelectControl, TextareaControl, TextControl, ToggleControl} from '@wordpress/components';
-import {PanelColorSettings} from '@wordpress/block-editor';
+import {PanelColorSettings, SETTINGS_DEFAULTS} from '@wordpress/block-editor';
 import {__} from '@wordpress/i18n';
 import {setFormSettings, useFormState, useFormStateDispatch} from '../../stores/form-state';
 import {getWindowData} from '@givewp/form-builder/common';
 import debounce from 'lodash.debounce';
-import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
 
 const {formDesigns} = getWindowData();
 
@@ -12,7 +11,16 @@ const designOptions = Object.values(formDesigns).map(({id, name}) => ({value: id
 
 const FormDesignSettings = () => {
     const {
-        settings: {designId, showHeading, heading, showDescription, description, primaryColor, secondaryColor},
+        settings: {
+            designId,
+            showHeader,
+            showHeading,
+            heading,
+            showDescription,
+            description,
+            primaryColor,
+            secondaryColor,
+        },
     } = useFormState();
     const dispatch = useFormStateDispatch();
 
@@ -39,6 +47,13 @@ const FormDesignSettings = () => {
                         label={__('Description', 'give')}
                         value={description}
                         onChange={(description) => dispatch(setFormSettings({description}))}
+                    />
+                </PanelRow>
+                <PanelRow>
+                    <ToggleControl
+                        label={__('Show Header', 'give')}
+                        checked={showHeader}
+                        onChange={() => dispatch(setFormSettings({showHeader: !showHeader}))}
                     />
                 </PanelRow>
                 <PanelRow>

--- a/packages/form-builder/src/types/formSettings.ts
+++ b/packages/form-builder/src/types/formSettings.ts
@@ -4,6 +4,7 @@ import {FormStatus} from "@givewp/form-builder/types/formStatus";
  * @since 0.1.0
  */
 export type FormSettings = {
+    showHeader: boolean;
     showHeading: boolean;
     showDescription: boolean;
     formTitle: string;

--- a/src/NextGen/DonationForm/Properties/FormSettings.php
+++ b/src/NextGen/DonationForm/Properties/FormSettings.php
@@ -13,6 +13,10 @@ class FormSettings implements Arrayable, Jsonable
     /**
      * @var boolean
      */
+    public $showHeader;
+    /**
+     * @var boolean
+     */
     public $showHeading;
     /**
      * @var boolean
@@ -98,6 +102,7 @@ class FormSettings implements Arrayable, Jsonable
     {
         $self = new self();
 
+        $self->showHeader = $array['showHeader'] ?? true;
         $self->showHeading = $array['showHeading'] ?? true;
         $self->heading = $array['heading'] ?? __('Support Our Cause', 'give');
         $self->showDescription = $array['showDescription'] ?? true;

--- a/src/NextGen/DonationForm/resources/app/DonationFormApp.tsx
+++ b/src/NextGen/DonationForm/resources/app/DonationFormApp.tsx
@@ -48,7 +48,7 @@ function App() {
     if (form.design?.isMultiStep) {
         return (
             <DonationFormStateProvider initialState={initialState}>
-                <MultiStepForm sections={form.nodes} showHeader />
+                <MultiStepForm sections={form.nodes} showHeader={form.settings?.showHeader} />
             </DonationFormStateProvider>
         );
     }

--- a/src/NextGen/DonationForm/resources/app/form/Header.tsx
+++ b/src/NextGen/DonationForm/resources/app/form/Header.tsx
@@ -27,38 +27,40 @@ const formatGoalAmount = (amount: number) => {
 export default function Header() {
     return (
         <DonationFormErrorBoundary>
-            <HeaderTemplate
-                Title={() => form.settings?.showHeading && <HeaderTitleTemplate text={form.settings.heading} />}
-                Description={() =>
-                    form.settings?.showDescription && <HeaderDescriptionTemplate text={form.settings.description} />
-                }
-                Goal={() =>
-                    form.goal?.show && (
-                        <GoalTemplate
-                            currency={form.currency}
-                            type={form.goal.type as GoalType}
-                            goalLabel={form.goal.label}
-                            progressPercentage={form.goal.progressPercentage}
-                            currentAmount={form.goal.currentAmount}
-                            currentAmountFormatted={
-                                form.goal.typeIsMoney
-                                    ? formatGoalAmount(form.goal.currentAmount)
-                                    : form.goal.currentAmount.toString()
-                            }
-                            targetAmount={form.goal.targetAmount}
-                            targetAmountFormatted={
-                                form.goal.typeIsMoney
-                                    ? formatGoalAmount(form.goal.targetAmount)
-                                    : form.goal.targetAmount.toString()
-                            }
-                            totalRevenue={form.stats.totalRevenue}
-                            totalRevenueFormatted={formatGoalAmount(form.stats.totalRevenue)}
-                            totalCountValue={form.stats.totalCountValue}
-                            totalCountLabel={form.stats.totalCountLabel}
-                        />
-                    )
-                }
-            />
+            {form.settings?.showHeader && (
+                <HeaderTemplate
+                    Title={() => form.settings?.showHeading && <HeaderTitleTemplate text={form.settings.heading} />}
+                    Description={() =>
+                        form.settings?.showDescription && <HeaderDescriptionTemplate text={form.settings.description} />
+                    }
+                    Goal={() =>
+                        form.goal?.show && (
+                            <GoalTemplate
+                                currency={form.currency}
+                                type={form.goal.type as GoalType}
+                                goalLabel={form.goal.label}
+                                progressPercentage={form.goal.progressPercentage}
+                                currentAmount={form.goal.currentAmount}
+                                currentAmountFormatted={
+                                    form.goal.typeIsMoney
+                                        ? formatGoalAmount(form.goal.currentAmount)
+                                        : form.goal.currentAmount.toString()
+                                }
+                                targetAmount={form.goal.targetAmount}
+                                targetAmountFormatted={
+                                    form.goal.typeIsMoney
+                                        ? formatGoalAmount(form.goal.targetAmount)
+                                        : form.goal.targetAmount.toString()
+                                }
+                                totalRevenue={form.stats.totalRevenue}
+                                totalRevenueFormatted={formatGoalAmount(form.stats.totalRevenue)}
+                                totalCountValue={form.stats.totalCountValue}
+                                totalCountLabel={form.stats.totalCountLabel}
+                            />
+                        )
+                    }
+                />
+            )}
         </DonationFormErrorBoundary>
     );
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds a simple `showHeader` settings to the form builder that makes it possible to show or hide the entire header above the form - or in multi-step, the first static step.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form builder and donation form.

## Visuals
<img width="275" alt="Screenshot 2023-05-16 at 1 20 13 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/e952355e-51d2-4816-9f76-4e092cdf8efe">

![2023-05-16 13 19 30](https://github.com/impress-org/givewp-next-gen/assets/10138447/06476fd2-7def-4a48-a5bf-d710732a75a5)


<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- pull branch and run `npm run dev`
- open a next gen form and use the showHeader settings


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

