### PR TITLE
Refactor: add generic hook and additional parameter

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -175,14 +175,23 @@ class ConvertDonationFormBlocksToFieldsApi
                             if (!is_user_logged_in()) {
                                 $field->required();
                             }
-                            
+
                             $field->rules(new AuthenticationRule());
                         }
                     });
 
             default:
                 $customField = apply_filters(
+                    'givewp_donation_form_block_render',
+                    null,
+                    $block,
+                    $blockIndex,
+                    $this->formId
+                );
+
+                $customField = apply_filters(
                     "givewp_donation_form_block_render_{$blockName}",
+                    $customField,
                     $block,
                     $blockIndex,
                     $this->formId

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -104,13 +104,13 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
-     * @unreleased add blockIndex for unique field names, add filter `givewp_donation_form_block_render_{$blockName}`
+     * @unreleased add blockIndex for unique field names, add filter `givewp_donation_form_block_render` filters
      * @since 0.1.0
      *
-     * @throws EmptyNameException
+     * @return Node|null
      * @throws NameCollisionException
      *
-     * @return Node|null
+     * @throws EmptyNameException
      */
     protected function createNodeFromBlockWithUniqueAttributes(BlockModel $block, int $blockIndex)
     {

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
@@ -112,7 +112,7 @@ final class TestConvertDonationFormBlocksToFieldsApi extends TestCase
                 return Email::make('givewp-custom-block');
             },
             10,
-            2
+            3
         );
 
         $formSchema = (new ConvertDonationFormBlocksToFieldsApi())($blocks, $formId);

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
@@ -108,7 +108,7 @@ final class TestConvertDonationFormBlocksToFieldsApi extends TestCase
 
         add_filter(
             'givewp_donation_form_block_render_givewp/givewp-custom-block',
-            static function (BlockModel $block, int $blockIndex) {
+            static function ($node, BlockModel $block, int $blockIndex) {
                 return Email::make('givewp-custom-block');
             },
             10,


### PR DESCRIPTION
## Description

This adds a generic `givewp_donation_form_block_render` hook and also adds a missing parameter to the existing hook. The filter was previously passing the block as the first parameter, but this isn't correct. For a filter the first parameter isn't context but the value being filtered. This makes it problematic for multiple functions firing on the same hook, and makes it impossible to chain hooks — as is being done now with the addition of the new hook.

Related: https://github.com/impress-org/give-fee-recovery/pull/323

## Affects

The `givewp_donation_form_block_render_{$blockName}` hook.

## Testing Instructions

I believe the only plugin using this hook so far is Fee Recovery. So make sure that still works with the new PR.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

