### PR TITLE
Refactor: replace ReactDOMServer function with temporary rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
                 "react": "^18.2.0",
                 "react-ace": "^10.1.0",
                 "react-currency-input-field": "^3.6.10",
-                "react-dom": "^18.2.0",
                 "react-error-boundary": "^3.1.4",
                 "react-hook-form": "^7.42.1",
                 "react-quill": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,15 +38,14 @@
         "react": "^18.2.0",
         "react-ace": "^10.1.0",
         "react-currency-input-field": "^3.6.10",
-        "react-dom": "^18.2.0",
         "react-error-boundary": "^3.1.4",
         "react-hook-form": "^7.42.1",
+        "react-quill": "^2.0.0",
         "react-select": "^5.7.0",
         "react-shepherd": "^4.2.0",
+        "react-use-clipboard": "^1.0.9",
         "swr": "^2.0.1",
-        "use-immer": "^0.9.0",
-        "react-quill": "^2.0.0",
-        "react-use-clipboard": "^1.0.9"
+        "use-immer": "^0.9.0"
     },
     "devDependencies": {
         "@types/react": "^18.0.27",

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/steps/withText.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/steps/withText.tsx
@@ -1,48 +1,70 @@
-import {renderToStaticMarkup} from "react-dom/server";
-import Logo from "@givewp/form-builder/components/icons/logo";
-import {Button} from "@wordpress/components";
-import {__, sprintf} from "@wordpress/i18n";
-import {createInterpolateElement} from "@wordpress/element";
+import {render} from '@wordpress/element';
+import Logo from '@givewp/form-builder/components/icons/logo';
+import {Button} from '@wordpress/components';
+import {__, sprintf} from '@wordpress/i18n';
 
 const TextContent = ({title, description, stepNumber, stepCount, isFirst, isLast}) => {
     return (
         <div>
             {isFirst && (
-                <div style={{display: "flex", justifyContent: 'center', margin: '0 auto var(--givewp-spacing-4)'}}>
-                    <Logo/>
+                <div style={{display: 'flex', justifyContent: 'center', margin: '0 auto var(--givewp-spacing-4)'}}>
+                    <Logo />
                 </div>
             )}
-            {!isFirst && !isLast &&(
-                <div style={{display:'flex', backgroundColor: 'var(--givewp-blue-25)', fontSize: '12px',padding:'4px',borderRadius:'2px',justifyContent:'space-between', alignItems: 'center'}}>
+            {!isFirst && !isLast && (
+                <div
+                    style={{
+                        display: 'flex',
+                        backgroundColor: 'var(--givewp-blue-25)',
+                        fontSize: '12px',
+                        padding: '4px',
+                        borderRadius: '2px',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                    }}
+                >
                     <div>{sprintf(__('Step %s of %s', 'give'), stepNumber, stepCount)}</div>
-                    <Button variant='tertiary' className={'js-exit-tour'}>{__('Exit tour', 'give')}</Button>
+                    <Button variant="tertiary" className={'js-exit-tour'}>
+                        {__('Exit tour', 'give')}
+                    </Button>
                 </div>
             )}
-            <h3 style={{
-                fontSize: isFirst || isLast ? '20px' : '16px',
-                margin: 'var(--givewp-spacing-3) 0',
-            }}>{title}</h3>
+            <h3
+                style={{
+                    fontSize: isFirst || isLast ? '20px' : '16px',
+                    margin: 'var(--givewp-spacing-3) 0',
+                }}
+            >
+                {title}
+            </h3>
             <p style={{fontSize: '14px'}}>{description}</p>
         </div>
-    )
-}
+    );
+};
 
 const withText = (steps) => {
-
     return steps.map((step, index) => {
         const stepCountAdjustedForBookends = steps.length - 2;
-        const textContent = <TextContent
-            title={step.title}
-            description={step.text}
-            stepNumber={index}
-            stepCount={stepCountAdjustedForBookends}
-            isFirst={index === 0}
-            isLast={index === steps.length - 1}
-        />;
-        return {...step, ...{
-                text: renderToStaticMarkup(textContent)
-            }}
-    })
-}
+        const textContent = (
+            <TextContent
+                title={step.title}
+                description={step.text}
+                stepNumber={index}
+                stepCount={stepCountAdjustedForBookends}
+                isFirst={index === 0}
+                isLast={index === steps.length - 1}
+            />
+        );
+        const tempContainer = document.createElement('div');
+        render(textContent, tempContainer);
 
-export default withText
+        return {
+            ...step,
+            ...{
+                text: tempContainer.innerHTML,
+            },
+        };
+    });
+};
+
+export default withText;

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/steps/withText.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/steps/withText.tsx
@@ -60,9 +60,7 @@ const withText = (steps) => {
 
         return {
             ...step,
-            ...{
-                text: tempContainer.innerHTML,
-            },
+            text: tempContainer.innerHTML,
         };
     });
 };


### PR DESCRIPTION
## Description

This pull request fixes an issue where ReactDOMServer was not being compiled by wp-scripts. To convert a React component to a string, we replaced it with a simple solution. We create an element in memory, render the component into it, then use the element's innerHTML string.

## Affects

`withText.tsx`, used on Onboarding

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

