### PR TITLE
Refactor: omit stripe name and email fields

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
@@ -134,6 +134,10 @@ class StripePaymentElementGateway extends PaymentGateway implements NextGenPayme
         return new RespondToBrowser([
             'clientSecret' => $intent->client_secret,
             'returnUrl' => $stripeGatewayData->successUrl,
+            'billingDetails' => [
+                'name' => trim("$donation->firstName $donation->lastName"),
+                'email' => $donation->email
+            ],
         ]);
     }
 

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -56,7 +56,19 @@ const StripeFields = ({gateway}) => {
         stripePaymentMethodIsCreditCard = event.value.type === 'card';
     };
 
-    return <PaymentElement onChange={handleOnChange} />;
+    return (
+        <PaymentElement
+            onChange={handleOnChange}
+            options={{
+                fields: {
+                    billingDetails: {
+                        name: 'never',
+                        email: 'never',
+                    },
+                },
+            }}
+        />
+    );
 };
 
 interface StripeSettings extends GatewaySettings {
@@ -114,12 +126,19 @@ const stripePaymentElementGateway: StripeGateway = {
         data: {
             clientSecret: string;
             returnUrl: string;
+            billingDetails: {
+                name: string;
+                email: string;
+            };
         };
     }): Promise<void> {
         const {error} = await this.stripe.confirmPayment({
             elements: this.elements,
             clientSecret: response.data.clientSecret,
             confirmParams: {
+                payment_method_data: {
+                    billing_details: response.data.billingDetails,
+                },
                 return_url: response.data.returnUrl,
             },
         });

--- a/tests/Feature/Gateways/Stripe/TestStripePaymentElementGateway.php
+++ b/tests/Feature/Gateways/Stripe/TestStripePaymentElementGateway.php
@@ -20,7 +20,7 @@ use Stripe\Customer;
 use Stripe\Exception\ApiErrorException;
 use Stripe\PaymentIntent;
 
-class NextGenStripeGatewayTest extends TestCase
+class TestStripePaymentElementGateway extends TestCase
 {
     use RefreshDatabase;
 
@@ -137,6 +137,10 @@ class NextGenStripeGatewayTest extends TestCase
             new RespondToBrowser([
                 'clientSecret' => $stripePaymentIntent->client_secret,
                 'returnUrl' => $gatewayData['successUrl'],
+                'billingDetails' => [
+                    'name' => trim("$donation->firstName $donation->lastName"),
+                    'email' => $donation->email
+                ]
             ])
         );
     }

--- a/tests/Feature/Gateways/Stripe/TestStripePaymentElementGatewaySubscriptionModule.php
+++ b/tests/Feature/Gateways/Stripe/TestStripePaymentElementGatewaySubscriptionModule.php
@@ -16,7 +16,7 @@ use Stripe\Customer;
 use Stripe\Plan;
 use Stripe\Product;
 
-class NextGenStripeGatewaySubscriptionModuleTest extends TestCase
+class TestStripePaymentElementGatewaySubscriptionModule extends TestCase
 {
     use RefreshDatabase;
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves: https://feedback.givewp.com/next-gen/p/error-occurs-when-using-ideal-or-bancontact-with-new-stripe-gateway

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Some payment methods add their own additional name and email fields.  These are redundant after the donor has already filled them out on the GiveWP form so we can omit them and provide the field data from the form submission. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Stripe payment methods that add their own name and email fields.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Before**

<img width="683" alt="Screenshot 2023-06-14 at 12 13 35 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/74b56ced-36db-4e5f-aba7-d26a93c1cdd1">

**After**

<img width="682" alt="Screenshot 2023-06-14 at 12 12 46 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/272ac576-b142-4736-a60b-aea3fc447dc4">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- test out using Ideal and Bancontact

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

