### PR TITLE
Fix: order recurring options before updating

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -17,16 +17,11 @@ import RecurringDonationsPromo from '@givewp/form-builder/promos/recurring-donat
 import {getFormBuilderData} from '@givewp/form-builder/common/getWindowData';
 import {useCallback} from '@wordpress/element';
 
-const getOrderedRecurringBillingPeriodOptions = (options) => {
-    const orderedOptions = [];
+const compareBillingPeriods = (val1: string, val2:string ): number => {
+    const index1 = Object.keys(periodLookup).indexOf(val1);
+    const index2 = Object.keys(periodLookup).indexOf(val2);
 
-    Object.keys(periodLookup).forEach((key) => {
-        if (options.includes(key)) {
-            orderedOptions.push(key);
-        }
-    });
-
-    return orderedOptions;
+    return index1 - index2;
 };
 
 const Inspector = ({attributes, setAttributes}) => {
@@ -49,9 +44,8 @@ const Inspector = ({attributes, setAttributes}) => {
 
     const addBillingPeriodOption = useCallback(
         (value) => {
-            const options = getOrderedRecurringBillingPeriodOptions(
-                Array.from(new Set(recurringBillingPeriodOptions.concat([value])))
-            );
+            const options = Array.from(new Set(recurringBillingPeriodOptions.concat([value])));
+            options.sort(compareBillingPeriods);
 
             setAttributes({
                 recurringBillingPeriodOptions: options,
@@ -61,11 +55,11 @@ const Inspector = ({attributes, setAttributes}) => {
     );
     const removeBillingPeriodOption = useCallback(
         (value) => {
-            const options = getOrderedRecurringBillingPeriodOptions(
-                recurringBillingPeriodOptions.filter((option) => option !== value)
-            );
+            const options = recurringBillingPeriodOptions.filter((option) => option !== value);
 
             if (recurringBillingPeriodOptions.length > 1) {
+                options.sort(compareBillingPeriods);
+
                 setAttributes({
                     recurringBillingPeriodOptions: options,
                 });

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -15,6 +15,19 @@ import {CurrencyControl} from '@givewp/form-builder/common/currency';
 import periodLookup from '../period-lookup';
 import RecurringDonationsPromo from '@givewp/form-builder/promos/recurring-donations';
 import {getFormBuilderData} from '@givewp/form-builder/common/getWindowData';
+import {useCallback} from '@wordpress/element';
+
+const getOrderedRecurringBillingPeriodOptions = (options) => {
+    const orderedOptions = [];
+
+    Object.keys(periodLookup).forEach((key) => {
+        if (options.includes(key)) {
+            orderedOptions.push(key);
+        }
+    });
+
+    return orderedOptions;
+};
 
 const Inspector = ({attributes, setAttributes}) => {
     const {
@@ -34,18 +47,32 @@ const Inspector = ({attributes, setAttributes}) => {
         recurringOptInDefaultBillingPeriod,
     } = attributes;
 
-    const addBillingPeriodOption = (value) => {
-        setAttributes({
-            recurringBillingPeriodOptions: Array.from(new Set(recurringBillingPeriodOptions.concat([value]))),
-        });
-    };
-    const removeBillingPeriodOption = (value) => {
-        if (recurringBillingPeriodOptions.length > 1) {
+    const addBillingPeriodOption = useCallback(
+        (value) => {
+            const options = getOrderedRecurringBillingPeriodOptions(
+                Array.from(new Set(recurringBillingPeriodOptions.concat([value])))
+            );
+
             setAttributes({
-                recurringBillingPeriodOptions: recurringBillingPeriodOptions.filter((option) => option !== value),
+                recurringBillingPeriodOptions: options,
             });
-        }
-    };
+        },
+        [recurringBillingPeriodOptions]
+    );
+    const removeBillingPeriodOption = useCallback(
+        (value) => {
+            const options = getOrderedRecurringBillingPeriodOptions(
+                recurringBillingPeriodOptions.filter((option) => option !== value)
+            );
+
+            if (recurringBillingPeriodOptions.length > 1) {
+                setAttributes({
+                    recurringBillingPeriodOptions: options,
+                });
+            }
+        },
+        [recurringBillingPeriodOptions]
+    );
 
     const {gateways, recurringAddonData, gatewaySettingsUrl} = getFormBuilderData();
     const enabledGateways = gateways.filter((gateway) => gateway.enabled);

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -17,7 +17,7 @@ import RecurringDonationsPromo from '@givewp/form-builder/promos/recurring-donat
 import {getFormBuilderData} from '@givewp/form-builder/common/getWindowData';
 import {useCallback} from '@wordpress/element';
 
-const compareBillingPeriods = (val1: string, val2:string ): number => {
+const compareBillingPeriods = (val1: string, val2: string): number => {
     const index1 = Object.keys(periodLookup).indexOf(val1);
     const index2 = Object.keys(periodLookup).indexOf(val2);
 
@@ -45,6 +45,7 @@ const Inspector = ({attributes, setAttributes}) => {
     const addBillingPeriodOption = useCallback(
         (value) => {
             const options = Array.from(new Set(recurringBillingPeriodOptions.concat([value])));
+
             options.sort(compareBillingPeriods);
 
             setAttributes({
@@ -53,6 +54,7 @@ const Inspector = ({attributes, setAttributes}) => {
         },
         [recurringBillingPeriodOptions]
     );
+
     const removeBillingPeriodOption = useCallback(
         (value) => {
             const options = recurringBillingPeriodOptions.filter((option) => option !== value);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fix ensures the recurring period options are in the appropriate order (time-frame ascending) - regardless of the time/order in which you toggle them.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The recurring billing period options

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1092" alt="Screenshot 2023-06-14 at 1 36 16 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/0f230748-f066-42fa-b9d6-16e42c649e3e">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Toggle the recurring billing periods in different orders and make sure they are in ascending order (in terms of time frame)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204414138863604