### PR TITLE
Feature: calculate the default value of next donation amount level

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -163,7 +163,10 @@ const Inspector = ({attributes, setAttributes}) => {
                     <AddButton
                         onClick={() => {
                             const newLevels = [...levels];
-                            newLevels.push('');
+                            const lastLevel = newLevels[newLevels.length - 1];
+                            const nextLevel = lastLevel ? lastLevel * 2 : 10;
+
+                            newLevels.push(nextLevel.toString());
                             setAttributes({levels: newLevels});
                         }}
                     />


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This add a "smart default" to the donation amount levels setting by double the previous amount.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation amount block levels setting

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1089" alt="Screenshot 2023-06-14 at 1 52 58 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/bfdbff1d-8bfd-4eea-8428-d9d0b9d57556">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- build assets, go into a form and click "Add another level" on the donation amount levels.
- the next value should be double the amount of the previous level
- 
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

