### PR TITLE
Fix: prevent fixed donation amount settings breaking block

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks.json
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks.json
@@ -23,7 +23,7 @@
                         "500"
                     ],
                     "priceOption": "multi",
-                    "setPrice": "25",
+                    "setPrice": 25,
                     "customAmount": "true",
                     "customAmountMin": 1,
                     "recurringBillingPeriodOptions": [

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/Edit.tsx
@@ -37,8 +37,8 @@ const Edit = ({attributes, setAttributes}) => {
     const isFixedAmount = priceOption === 'set';
     const isRecurringAdmin = isRecurring && 'admin' === recurringDonationChoice;
     const isRecurringDonor = isRecurring && 'donor' === recurringDonationChoice;
-
-    const amountFormatted = formatCurrencyAmount(setPrice);
+    
+    const amountFormatted = formatCurrencyAmount(setPrice.toString());
 
     const DonationLevels = () => (
         <LevelGrid>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -106,7 +106,7 @@ const Inspector = ({attributes, setAttributes}) => {
                     <CurrencyControl
                         label={__('Set Donation', 'give')}
                         value={setPrice}
-                        onBlur={() => setPrice || setAttributes({setPrice: 25})}
+                        onBlur={() => !setPrice && setAttributes({setPrice: 25})}
                         onValueChange={(setPrice) => setAttributes({setPrice: setPrice ? parseInt(setPrice) : 0})}
                     />
                 )}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This resolves an issue that was breaking the donation amount block when interacting with the fixed donation amount setting.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation amount block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Build assets
- Update donation amount block setting to be _fixed donation_ and interact with the amount field. it should not break the block.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

