### PR TITLE
Feature: mount hooks to window for add-ons use

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/App.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/App.tsx
@@ -6,6 +6,7 @@ import defaultBlocks from './blocks.json';
 import Feedback from '@givewp/form-builder/feedback';
 import {BlockInstance} from '@wordpress/blocks';
 import './App.scss';
+import mountHooksToWindow from '@givewp/form-builder/hooks/mountHooksToWindow';
 import FormBuilderErrorBoundary from '@givewp/form-builder/errors/FormBuilderErrorBounday';
 
 const {blocks: initialBlocks, formSettings: initialFormSettings} = Storage.load();
@@ -25,6 +26,8 @@ if (initialBlocks instanceof Error) {
 if (ShortcutProvider === undefined) {
     console.error('ShortcutProvider is undefined.');
 }
+
+mountHooksToWindow();
 
 export default function App() {
     return (

--- a/src/FormBuilder/resources/js/form-builder/src/hooks/mountHooksToWindow.js
+++ b/src/FormBuilder/resources/js/form-builder/src/hooks/mountHooksToWindow.js
@@ -1,0 +1,12 @@
+import {useFieldNameValidator} from './useFieldNameValidator';
+import {useSelectedBlocks} from './useSelectedBlocks';
+
+export default function mountHooksToWindow() {
+    window.givewp = window.givewp || {};
+    window.givewp.hooks = window.givewp.hooks || {};
+
+    window.givewp.hooks = {
+        useFieldNameValidator,
+        useSelectedBlocks,
+    };
+}


### PR DESCRIPTION
## Description

This PR mounts form builder hooks to the window so that add-ons can make use of them. The primary reason is so add-ons have a simple way of adding name fields and checking for conflicts.

An even better way of going about this, if not too difficult, would be to make use of `block.supports` with something like:
```js
{
    supports: {
        fieldNames: {
            generateFrom: 'label'
        }
    }
}
```

That would automatically add the name attribute and property to the inspector in the Advanced section. That would be awesome.

## Affects

Nothing, just new functionality.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

