### PR TITLE
Fix: prevent conflict between custom amount field and donation levels

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from '@wordpress/element';
+import {useCallback, useRef} from '@wordpress/element';
 import type {AmountProps} from '@givewp/forms/propTypes';
 import CustomAmount from './CustomAmount';
 import AmountLevels from './AmountLevels';
@@ -29,10 +29,13 @@ export default function Amount({
     const currencySymbol = formatter.formatToParts().find(({type}) => type === 'currency').value;
 
     const isFixedAmount = !allowLevels;
-    const resetCustomAmountInput = () => {
-        customAmountInputRef.current.value = '';
-        customAmountInputRef.current.attributes.getNamedItem('value').value = '';
-    };
+    
+    const resetCustomAmountInput = useCallback(() => {
+        if (customAmountInputRef.current !== null) {
+            customAmountInputRef.current.value = '';
+            customAmountInputRef.current.attributes.getNamedItem('value').value = '';
+        }
+    }, [customAmountInputRef.current]);
 
     return (
         <>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fixes an issue when Donation Amount Levels were not working when the Custom Amount field was disabled.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation amount field on the donation form

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- Disable custom amount & publish.
- View the form and make sure you can click on the donation levels

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

