### PR TITLE
Feature: support v3 forms on give_form shortcode

### DIFF
--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -20,6 +20,7 @@ use Give\DonationForms\Repositories\DonationFormRepository;
 use Give\DonationForms\Routes\AuthenticationRoute;
 use Give\DonationForms\Routes\DonateRoute;
 use Give\DonationForms\Routes\ValidationRoute;
+use Give\DonationForms\Shortcodes\GiveFormShortcode;
 use Give\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\Framework\Routes\Route;
 use Give\Helpers\Hooks;
@@ -59,6 +60,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerRoutes();
         $this->registerFormDesigns();
         $this->registerSingleFormPage();
+        $this->registerShortcodes();
 
         Hooks::addAction('givewp_donation_form_created', StoreBackwardsCompatibleFormMeta::class);
         Hooks::addAction('givewp_donation_form_updated', StoreBackwardsCompatibleFormMeta::class);
@@ -162,5 +164,13 @@ class ServiceProvider implements ServiceProviderInterface
     protected function registerSingleFormPage()
     {
         Hooks::addFilter('template_include', TemplateHandler::class, 'handle', 11);
+    }
+
+    /**
+     * @unreleased
+     */
+    protected function registerShortcodes()
+    {
+        Hooks::addFilter('givewp_form_shortcode_output', GiveFormShortcode::class, '__invoke', 10, 2);
     }
 }

--- a/src/DonationForms/Shortcodes/GiveFormShortcode.php
+++ b/src/DonationForms/Shortcodes/GiveFormShortcode.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Give\DonationForms\Shortcodes;
+
+use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
+
+class GiveFormShortcode
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(string $output, array $atts): string
+    {
+        $formId = absint($atts['id']);
+        $isV3Form = (bool) give()->form_meta->get_meta($formId, 'formBuilderSettings', true);
+
+        if (!$isV3Form) {
+            return $output;
+        }
+
+        $controller = new BlockRenderController();
+        $blockAttributes = [
+            'formId' => $formId,
+            'blockId' => 'give-form-shortcode-' . uniqid(),
+        ];
+
+        return $controller->render($blockAttributes);
+    }
+}

--- a/src/DonationForms/Shortcodes/GiveFormShortcode.php
+++ b/src/DonationForms/Shortcodes/GiveFormShortcode.php
@@ -2,6 +2,7 @@
 
 namespace Give\DonationForms\Shortcodes;
 
+use Give\DonationForms\Actions\GenerateDonationFormViewRouteUrl;
 use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
 
 class GiveFormShortcode
@@ -14,7 +15,7 @@ class GiveFormShortcode
         $formId = absint($atts['id']);
         $isV3Form = (bool) give()->form_meta->get_meta($formId, 'formBuilderSettings', true);
 
-        if (!$isV3Form) {
+        if (!$formId || !$isV3Form) {
             return $output;
         }
 
@@ -24,6 +25,20 @@ class GiveFormShortcode
             'blockId' => 'give-form-shortcode-' . uniqid(),
         ];
 
-        return $controller->render($blockAttributes);
+        $output = $controller->render($blockAttributes);
+
+        if (!$output) {
+            $viewUrl = (new GenerateDonationFormViewRouteUrl())($formId);
+            $output = sprintf(
+                "<iframe
+                    src='%s'
+                    style='width: 1px;min-width: 100%%;border: 0;transition: height 0.25s;'
+                    onload='if( \"undefined\" !== typeof Give ) { Give.initializeIframeResize(this) }'
+                ></iframe>",
+                esc_url($viewUrl)
+            );
+        }
+
+        return $output;
     }
 }


### PR DESCRIPTION
Depends on https://github.com/impress-org/givewp/pull/6849

## Description

This pull request adds support to render v3 forms on the `give_form` shortcode hooking onto the recently added `givewp_form_shortcode_output` filter.

## Affects

`give_form` shortcode and the legacy Donation Form block as it uses the same shortcode to render the form.

## Testing Instructions

Add a legacy Donation Form block to a post/page, select a v3 donation form. The form must be rendered as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204525695989154
  - https://app.asana.com/0/0/1204994733742882