### PR TITLE
Feature: add AdvancedSettingsSlot to HOC

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -1,4 +1,4 @@
-import {InspectorControls, InspectorAdvancedControls} from '@wordpress/block-editor';
+import {InspectorAdvancedControls, InspectorControls} from '@wordpress/block-editor';
 import {useCallback, useMemo} from '@wordpress/element';
 import {getBlockSupport} from '@wordpress/blocks';
 import {slugify} from '@givewp/form-builder/common';
@@ -9,7 +9,7 @@ import {__} from '@wordpress/i18n';
 import Label from '@givewp/form-builder/blocks/fields/settings/Label';
 
 import {FieldSettings} from './types';
-import {FieldSettingsSlot, DisplaySettingsSlot} from './slots';
+import {AdvancedSettingsSlot, DisplaySettingsSlot, FieldSettingsSlot} from './slots';
 import {createHigherOrderComponent} from '@wordpress/compose';
 import {GiveWPSupports} from '@givewp/form-builder/supports/types';
 import {useState} from 'react';
@@ -178,6 +178,8 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
             )}
             {(fieldSettings.name || fieldSettings.storeAsDonorMeta) && (
                 <InspectorAdvancedControls>
+                    <AdvancedSettingsSlot />
+
                     {fieldSettings.name && (
                         <PanelRow>
                             <TextControl

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -178,7 +178,21 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
             )}
             {(fieldSettings.name || fieldSettings.storeAsDonorMeta) && (
                 <InspectorAdvancedControls>
-                    <AdvancedSettingsSlot />
+                    {fieldSettings.defaultValue && (
+                        <PanelRow>
+                            <TextControl
+                                label={__('Default Value', 'give')}
+                                value={attributes.defaultValue}
+                                help={[
+                                    __(
+                                        'The value of the field if the donor does not fill out this field. Leave blank in most cases.',
+                                        'give'
+                                    ),
+                                ]}
+                                onChange={(newDefaultValue) => setAttributes({defaultValue: newDefaultValue})}
+                            />
+                        </PanelRow>
+                    )}
 
                     {fieldSettings.name && (
                         <PanelRow>
@@ -199,6 +213,23 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
                             />
                         </PanelRow>
                     )}
+
+                    {fieldSettings.emailTag && (
+                        <PanelRow>
+                            <TextControl
+                                label={__('Email Tag', 'give')}
+                                value={attributes.emailTag}
+                                help={[
+                                    __(
+                                        'Use this email tag to dynamically output the data in supported GiveWP emails.',
+                                        'give'
+                                    ),
+                                ]}
+                                onChange={(newDefaultValue) => setAttributes({emailTag: newDefaultValue})}
+                            />
+                        </PanelRow>
+                    )}
+
                     {fieldSettings.storeAsDonorMeta && (
                         <PanelRow>
                             <ToggleControl

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -4,7 +4,7 @@ import {getBlockSupport} from '@wordpress/blocks';
 import {slugify} from '@givewp/form-builder/common';
 import normalizeFieldSettings from '@givewp/form-builder/supports/field-settings/normalizeFieldSettings';
 import {useFieldNameValidator} from '@givewp/form-builder/hooks';
-import {ExternalLink, PanelBody, PanelRow, TextControl, ToggleControl} from '@wordpress/components';
+import {ExternalLink, PanelBody, PanelRow, TextareaControl, TextControl, ToggleControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import Label from '@givewp/form-builder/blocks/fields/settings/Label';
 
@@ -127,7 +127,7 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
                         )}
                         {fieldSettings.description && (
                             <PanelRow>
-                                <TextControl
+                                <TextareaControl
                                     label={__('Description', 'give')}
                                     value={attributes.description}
                                     onChange={(newDescription) => {

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -183,7 +183,10 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
                 <AfterDisplaySettingsSlot />
             </InspectorControls>
 
-            {(fieldSettings.name || fieldSettings.storeAsDonorMeta) && (
+            {(fieldSettings.defaultValue ||
+                fieldSettings.name ||
+                fieldSettings.emailTag ||
+                fieldSettings.storeAsDonorMeta) && (
                 <InspectorAdvancedControls>
                     {fieldSettings.defaultValue && (
                         <PanelRow>

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -9,7 +9,7 @@ import {__} from '@wordpress/i18n';
 import Label from '@givewp/form-builder/blocks/fields/settings/Label';
 
 import {FieldSettings} from './types';
-import {AdvancedSettingsSlot, DisplaySettingsSlot, FieldSettingsSlot} from './slots';
+import {AfterDisplaySettingsSlot, AfterFieldSettingsSlot, DisplaySettingsSlot, FieldSettingsSlot} from './slots';
 import {createHigherOrderComponent} from '@wordpress/compose';
 import {GiveWPSupports} from '@givewp/form-builder/supports/types';
 import {useState} from 'react';
@@ -102,8 +102,11 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
     return (
         <>
             <BlockEdit />
-            {(fieldSettings.label || fieldSettings.required) && (
-                <InspectorControls>
+            <InspectorControls>
+                {(fieldSettings.label ||
+                    fieldSettings.placeholder ||
+                    fieldSettings.description ||
+                    fieldSettings.required) && (
                     <PanelBody title={__('Field Settings', 'give')} initialOpen={true}>
                         {fieldSettings.label && (
                             <PanelRow>
@@ -148,10 +151,11 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
                         {/* @ts-ignore */}
                         <FieldSettingsSlot />
                     </PanelBody>
-                </InspectorControls>
-            )}
-            {(fieldSettings.displayInAdmin || fieldSettings.displayInReceipt) && (
-                <InspectorControls>
+                )}
+
+                <AfterFieldSettingsSlot />
+
+                {(fieldSettings.displayInAdmin || fieldSettings.displayInReceipt) && (
                     <PanelBody title={__('Display Settings', 'give')} initialOpen={true}>
                         {fieldSettings.displayInAdmin && (
                             <PanelRow>
@@ -174,8 +178,11 @@ function FieldSettingsEdit({attributes, setAttributes, BlockEdit, fieldSettings}
                         {/* @ts-ignore */}
                         <DisplaySettingsSlot />
                     </PanelBody>
-                </InspectorControls>
-            )}
+                )}
+
+                <AfterDisplaySettingsSlot />
+            </InspectorControls>
+
             {(fieldSettings.name || fieldSettings.storeAsDonorMeta) && (
                 <InspectorAdvancedControls>
                     {fieldSettings.defaultValue && (

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/index.tsx
@@ -2,7 +2,7 @@ import {addFilter} from '@wordpress/hooks';
 
 import FieldSettingsHOC from './FieldSettingsHOC';
 import updateBlockTypes from './updateBlockTypes';
-import {AdvancedSettingsFill, DisplaySettingsFill, FieldSettingsFill} from './slots';
+import {AfterDisplaySettingsFill, AfterFieldSettingsFill, DisplaySettingsFill, FieldSettingsFill} from './slots';
 
 /**
  * Registers the necessary hooks for supports the field settings
@@ -16,6 +16,7 @@ export default function registerHooks() {
     // Mounts the field settings inspector slots so other plugins can extend the inspector controls
     window.givewp.form.slots = window.givewp.form.slots || {};
     window.givewp.form.slots.FieldSettingsFill = FieldSettingsFill;
+    window.givewp.form.slots.AfterFieldSettingsFill = AfterFieldSettingsFill;
     window.givewp.form.slots.DisplaySettingsFill = DisplaySettingsFill;
-    window.givewp.form.slots.AdvancedSettingsFill = AdvancedSettingsFill;
+    window.givewp.form.slots.AfterDisplaySettingsFill = AfterDisplaySettingsFill;
 }

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/index.tsx
@@ -1,8 +1,8 @@
-import {addFilter} from "@wordpress/hooks";
+import {addFilter} from '@wordpress/hooks';
 
-import FieldSettingsHOC from "./FieldSettingsHOC";
-import updateBlockTypes from "./updateBlockTypes";
-import {DisplaySettingsFill, FieldSettingsFill} from "./slots";
+import FieldSettingsHOC from './FieldSettingsHOC';
+import updateBlockTypes from './updateBlockTypes';
+import {AdvancedSettingsFill, DisplaySettingsFill, FieldSettingsFill} from './slots';
 
 /**
  * Registers the necessary hooks for supports the field settings
@@ -17,4 +17,5 @@ export default function registerHooks() {
     window.givewp.form.slots = window.givewp.form.slots || {};
     window.givewp.form.slots.FieldSettingsFill = FieldSettingsFill;
     window.givewp.form.slots.DisplaySettingsFill = DisplaySettingsFill;
+    window.givewp.form.slots.AdvancedSettingsFill = AdvancedSettingsFill;
 }

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/normalizeFieldSettings.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/normalizeFieldSettings.ts
@@ -34,5 +34,7 @@ export default function normalizeFieldSettings(settings: FieldSettingsSupport | 
         storeAsDonorMeta: getSupportSetting('storeAsDonorMeta', true, false),
         displayInAdmin: getSupportSetting('displayInAdmin', true, true),
         displayInReceipt: getSupportSetting('displayInReceipt', true, true),
+        defaultValue: getSupportSetting('defaultValue', false, ''),
+        emailTag: getSupportSetting('emailTag', false, ''),
     };
 }

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/slots.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/slots.ts
@@ -10,5 +10,15 @@ const {Slot: FieldSettingsSlot, Fill: FieldSettingsFill} = createSlotFill('GiveW
 const {Slot: DisplaySettingsSlot, Fill: DisplaySettingsFill} = createSlotFill(
     'GiveWP/FieldSettings/DisplaySettingSlot'
 );
+const {Slot: AdvancedSettingsSlot, Fill: AdvancedSettingsFill} = createSlotFill(
+    'GiveWP/FieldSettings/AdvancedSettingSlot'
+);
 
-export {FieldSettingsSlot, FieldSettingsFill, DisplaySettingsSlot, DisplaySettingsFill};
+export {
+    FieldSettingsSlot,
+    FieldSettingsFill,
+    DisplaySettingsSlot,
+    DisplaySettingsFill,
+    AdvancedSettingsSlot,
+    AdvancedSettingsFill,
+};

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/slots.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/slots.ts
@@ -7,18 +7,25 @@ import {createSlotFill} from '@wordpress/components';
  * @unreleased
  */
 const {Slot: FieldSettingsSlot, Fill: FieldSettingsFill} = createSlotFill('GiveWP/FieldSettings/FieldSettingSlot');
+
+const {Slot: AfterFieldSettingsSlot, Fill: AfterFieldSettingsFill} = createSlotFill(
+    'GiveWP/FieldSettings/AfterFieldSettingsSlot'
+);
 const {Slot: DisplaySettingsSlot, Fill: DisplaySettingsFill} = createSlotFill(
     'GiveWP/FieldSettings/DisplaySettingSlot'
 );
-const {Slot: AdvancedSettingsSlot, Fill: AdvancedSettingsFill} = createSlotFill(
-    'GiveWP/FieldSettings/AdvancedSettingSlot'
+
+const {Slot: AfterDisplaySettingsSlot, Fill: AfterDisplaySettingsFill} = createSlotFill(
+    'GiveWP/FieldSettings/AfterDisplaySettingsSlot'
 );
 
 export {
     FieldSettingsSlot,
     FieldSettingsFill,
+    AfterFieldSettingsSlot,
+    AfterFieldSettingsFill,
     DisplaySettingsSlot,
     DisplaySettingsFill,
-    AdvancedSettingsSlot,
-    AdvancedSettingsFill,
+    AfterDisplaySettingsSlot,
+    AfterDisplaySettingsFill,
 };

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/types.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/types.ts
@@ -7,6 +7,8 @@ export type FieldSettings = {
     storeAsDonorMeta: FieldSettingProperty;
     displayInAdmin: FieldSettingProperty;
     displayInReceipt: FieldSettingProperty;
+    defaultValue: FieldSettingProperty;
+    emailTag: FieldSettingProperty;
 };
 
 export type FieldSettingsSupport =
@@ -20,6 +22,8 @@ export type FieldSettingsSupport =
           storeAsDonorMeta: FieldSettingProperty | boolean;
           displayInAdmin: FieldSettingProperty | boolean;
           displayInReceipt: FieldSettingProperty | boolean;
+          defaultValue: FieldSettingProperty | boolean;
+          emailTag: FieldSettingProperty | boolean;
       };
 
 export type FieldSettingProperty =

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/updateBlockTypes.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/updateBlockTypes.ts
@@ -74,6 +74,20 @@ export default function updateBlockTypes(settings) {
         };
     }
 
+    if (fieldSettings.defaultValue) {
+        fieldAttributes.defaultValue = {
+            type: 'string',
+            default: fieldSettings.defaultValue.default,
+        };
+    }
+
+    if (fieldSettings.emailTag) {
+        fieldAttributes.emailTag = {
+            type: 'string',
+            default: fieldSettings.emailTag.default,
+        };
+    }
+
     settings.attributes = {
         ...settings.attributes,
         ...fieldAttributes,


### PR DESCRIPTION
## Description

This pull request adds a new slot, `<AdvancedSettingsSlot>`, to the Field Settings HOC. Add-ons can use this slot to add their own custom settings to the _Advanced_ section in the Inspector.

Directly using the `<InspectorAdvancedConstrols>` slot causes a rendering conflict with the fields added by the HOC.

## Visuals
Example of usage:
![CleanShot 2023-07-11 at 14 53 20](https://github.com/impress-org/givewp-next-gen/assets/3921017/503a9bd6-0809-4b83-be70-d227057a7610)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

