### PR TITLE
Feature: add currency setting exchange rate fraction digits

### DIFF
--- a/src/DonationForms/resources/registrars/templates/groups/DonationAmount/DonationAmountCurrencySwitcherMessage.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/DonationAmount/DonationAmountCurrencySwitcherMessage.tsx
@@ -54,21 +54,25 @@ export default function DonationAmountCurrencySwitcherMessage({
 }: DonationAmountCurrencySwitcherMessageProps) {
     const {useWatch, useCurrencyFormatter} = window.givewp.form.hooks;
     const currency = useWatch({name: 'currency'});
-    const newCurrencyFormatter = useCurrencyFormatter(currency);
 
     const baseCurrency = currencySettings.find((setting) => setting.exchangeRate === 0)?.id ?? 'USD';
 
     const baseCurrencyFormatter = useCurrencyFormatter(baseCurrency);
 
-    const newCurrencyRate =
-        currencySettings.find((setting) => setting.id === currency)?.exchangeRate.toFixed(2) ?? '1.00';
+    const newCurrencySetting = currencySettings.find((setting) => setting.id === currency);
+
+    const newCurrencyRate = newCurrencySetting?.exchangeRate ?? Number('1.00');
+
+    const newCurrencyRateFormatter = useCurrencyFormatter(currency, {
+        minimumFractionDigits: newCurrencySetting.exchangeRateFractionDigits,
+    });
 
     return (
         <CurrencySwitcherMessage
             baseCurrency={baseCurrency}
             message={message.replace('1.00', baseCurrencyFormatter.format(1))}
             newCurrency={currency}
-            newCurrencyRate={newCurrencyFormatter.format(Number(newCurrencyRate))}
+            newCurrencyRate={newCurrencyRateFormatter.format(newCurrencyRate)}
         />
     );
 }

--- a/src/DonationForms/resources/types.ts
+++ b/src/DonationForms/resources/types.ts
@@ -23,6 +23,7 @@ export type CurrencySwitcherSetting = {
     id: string;
     exchangeRate: number;
     gateways: string[];
+    exchangeRateFractionDigits: number;
 };
 
 export interface FormData {

--- a/src/Framework/FieldsAPI/Properties/DonationForm/CurrencySwitcherSetting.php
+++ b/src/Framework/FieldsAPI/Properties/DonationForm/CurrencySwitcherSetting.php
@@ -21,15 +21,24 @@ class CurrencySwitcherSetting implements JsonSerializable
      * @var string[]
      */
     protected $gateways = [];
+    /**
+     * @var int
+     */
+    protected $exchangeRateFractionDigits;
 
     /**
      * @unreleased
      */
-    public function __construct(string $id, float $exchangeRate = 0, array $gateways = [])
-    {
+    public function __construct(
+        string $id,
+        float $exchangeRate = 0,
+        array $gateways = [],
+        int $exchangeRateFractionDigits = 2
+    ) {
         $this->id = $id;
         $this->exchangeRate = $exchangeRate;
         $this->gateways = $gateways;
+        $this->exchangeRateFractionDigits = $exchangeRateFractionDigits;
     }
 
     /**
@@ -56,6 +65,16 @@ class CurrencySwitcherSetting implements JsonSerializable
     public function exchangeRate(float $rate): CurrencySwitcherSetting
     {
         $this->exchangeRate = $rate;
+
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function exchangeRateFractionDigits(int $exchangeRateFractionDigits): CurrencySwitcherSetting
+    {
+        $this->exchangeRateFractionDigits = $exchangeRateFractionDigits;
 
         return $this;
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds support for exchange rate fraction digits to display the donor.

Note: this will only affect the message displayed to the donor, not the actual donation amount.  Learn more [here](https://givewp.com/documentation/add-ons/currency-switcher/)

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Adds new exchange rate fraction digit property to the CurrencySwitcherSetting

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
<img width="1270" alt="Screenshot 2023-07-20 at 5 02 06 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/dd3b7556-5041-44e4-a9b1-d1a451f0e489">

<img width="807" alt="Screenshot 2023-07-20 at 5 02 18 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/9a622c87-4c8f-4e28-9cc0-d6d5b131a33f">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Programatically:

```
use Give\Framework\FieldsAPI\DonationForm;
use Give\Framework\FieldsAPI\Properties\DonationForm\CurrencySwitcherSetting;

add_action('givewp_donation_form_schema', static function (DonationForm $form) {
    $currencySwitcherSettings = [
        new CurrencySwitcherSetting('USD', 0, ['test-gateway', 'stripe_payment_element']),
        new CurrencySwitcherSetting('EUR', 0.911699, ['test-gateway', 'stripe_payment_element'], 6),
    ];

    $form->currencySwitcherSettings(...$currencySwitcherSettings);
    $form->currencySwitcherMessage(
        'The current exchange rate is 1.00 {base_currency} equals {new_currency_rate} {new_currency}.'
    );
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

