### PR TITLE
NextGen editor styles no longer affect the visual appearance of radio and checkbox components

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
@@ -12,7 +12,7 @@
  */
 
 .givewp-next-gen-sidebar.givewp-next-gen-sidebar-primary {
-    input,
+    input:not([type=radio]):not([type=checkbox]),
     textarea,
     .components-form-token-field__input-container {
         width: 100%;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #219

## Description

This PR resolves the issue where NextGen editor styles were altering the visual appearance of the radio and checkbox components inside InspectorControls -> PanelBody. 

## Affects

Radio and Checkbox component visual appearance 

## Visuals
![Screen Capture_select-area_20230721132023](https://github.com/impress-org/givewp-next-gen/assets/4222590/d7c54c3f-c4d9-4572-bba9-b652a0e7dc93)

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

