### PR TITLE
Feature: Add form grid settings to builder

### DIFF
--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -127,6 +127,26 @@ class FormSettings implements Arrayable, Jsonable
     public $emailFromEmail;
 
     /**
+     * @var boolean
+     */
+    public $formGridCustomize;
+
+    /**
+     * @var string
+     */
+    public $formGridRedirectUrl;
+
+    /**
+     * @var string
+     */
+    public $formGridDonateButtonText;
+
+    /**
+     * @var boolean
+     */
+    public $formGridHideDocumentationLink;
+
+    /**
      * @since 0.1.0
      */
     public static function fromArray(array $array): self

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -185,8 +185,13 @@ class FormSettings implements Arrayable, Jsonable
             'give'
         );
         $self->formStatus = !empty($array['formStatus']) ? new DonationFormStatus($array['formStatus']) : DonationFormStatus::DRAFT();
-        $self->emailTemplateOptions = $array['emailTemplateOptions'] ?? [];
 
+        $self->formGridCustomize = $array['formGridCustomize'] ?? false;
+        $self->formGridRedirectUrl = $array['formGridRedirectUrl'] ?? '';
+        $self->formGridDonateButtonText = $array['formGridDonateButtonText'] ?? '';
+        $self->formGridHideDocumentationLink = $array['formGridHideDocumentationLink'] ?? false;
+
+        $self->emailTemplateOptions = $array['emailTemplateOptions'] ?? [];
 
         $self->emailOptionsStatus = $array['emailOptionsStatus'] ?? 'global';
 

--- a/src/FormBuilder/Actions/UpdateFormGridMeta.php
+++ b/src/FormBuilder/Actions/UpdateFormGridMeta.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Give\FormBuilder\Actions;
+
+use Give\DonationForms\Models\DonationForm;
+
+/**
+ * Update email settings on backwards compatible form meta.
+ *
+ * @unreleased
+ */
+class UpdateFormGridMeta
+{
+    /**
+     * @unreleased
+     * @param  DonationForm  $form
+     */
+    public function __invoke(DonationForm $form)
+    {
+        give()->form_meta->update_meta($form->id, "_give_form_grid_option", $form->settings->formGridCustomize ? 'custom' : 'global');
+        give()->form_meta->update_meta($form->id, "_give_form_grid_redirect_url", $form->settings->formGridRedirectUrl);
+        give()->form_meta->update_meta($form->id, "_give_form_grid_donate_button_text", $form->settings->formGridDonateButtonText);
+    }
+}

--- a/src/FormBuilder/ServiceProvider.php
+++ b/src/FormBuilder/ServiceProvider.php
@@ -7,6 +7,7 @@ use Give\FormBuilder\Actions\DequeueAdminScriptsInFormBuilder;
 use Give\FormBuilder\Actions\DequeueAdminStylesInFormBuilder;
 use Give\FormBuilder\Actions\UpdateEmailSettingsMeta;
 use Give\FormBuilder\Actions\UpdateEmailTemplateMeta;
+use Give\FormBuilder\Actions\UpdateFormGridMeta;
 use Give\FormBuilder\EmailPreview\Routes\RegisterEmailPreviewRoutes;
 use Give\FormBuilder\Routes\CreateFormRoute;
 use Give\FormBuilder\Routes\EditFormRoute;
@@ -54,6 +55,7 @@ class ServiceProvider implements ServiceProviderInterface
         });
 
         add_action('givewp_form_builder_updated', static function (DonationForm $form) {
+            give(UpdateFormGridMeta::class)->__invoke($form);
             give(UpdateEmailSettingsMeta::class)->__invoke($form);
             give(UpdateEmailTemplateMeta::class)->__invoke($form);
         });

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Primary/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Primary/index.tsx
@@ -11,6 +11,7 @@ import {
     FormSummarySettings,
     ReceiptSettings,
     RegistrationSettings,
+    FormGridSettings,
 } from '../../../settings';
 import {PopoutSlot} from '../popout';
 import {useEffect} from 'react';
@@ -39,6 +40,7 @@ const tabs = [
                 <DonationGoalSettings />
                 <RegistrationSettings />
                 <ReceiptSettings />
+                <FormGridSettings />
                 <EmailSettings />
                 {/*The settings below have not been implemented yet.*/}
                 {/*<OfflineDonationsSettings/>*/}

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-grid/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-grid/index.tsx
@@ -1,0 +1,68 @@
+import {__} from '@wordpress/i18n';
+import {ExternalLink, PanelBody, PanelRow, TextControl, ToggleControl} from '@wordpress/components';
+import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
+
+const FormGridSettings = () => {
+    const {
+        settings: {formGridCustomize, formGridRedirectUrl, formGridDonateButtonText, formGridHideDocumentationLink},
+    } = useFormState();
+    const dispatch = useFormStateDispatch();
+
+    return (
+        <PanelBody title={__('Form Grid', 'give')} initialOpen={false}>
+            <PanelRow>
+                <ToggleControl
+                    label={__('Customize form grid', 'give')}
+                    checked={formGridCustomize}
+                    onChange={() => {
+                        dispatch(setFormSettings({formGridCustomize: !formGridCustomize}));
+                    }}
+                />
+            </PanelRow>
+
+            {formGridCustomize && (
+                <>
+                    <PanelRow>
+                        <TextControl
+                            label={__('Redirect Url', 'give')}
+                            placeholder={'https://example.com/donation'}
+                            help={__('The full URL of the page you want this form to redirect to when clicked on from the Form Grid. This only applies when the Form Grid uses the "Redirect" method.', 'give')}
+                            value={formGridRedirectUrl}
+                            onChange={(formGridRedirectUrl) => dispatch(setFormSettings({formGridRedirectUrl}))}
+                        />
+                    </PanelRow>
+                    <PanelRow>
+                        <TextControl
+                            label={__('Donate Button Text', 'give')}
+                            placeholder={__('Donate', 'give')}
+                            help={__('The text on the Donate Button for this form when displayed on the Form Grid. This setting only applies if the Donate Button display option is enabled in your Form Grid.', 'give')}
+                            value={formGridDonateButtonText}
+                            onChange={(formGridDonateButtonText) => dispatch(setFormSettings({formGridDonateButtonText}))}
+                        />
+                    </PanelRow>
+                </>
+            )}
+
+            {!formGridHideDocumentationLink && (
+                <div style={{
+                    position: 'relative',
+                    backgroundColor: 'var(--givewp-grey-25)',
+                    padding: 'var(--givewp-spacing-4)',
+                }}>
+                    <h3 style={{
+                        fontSize: 'var(--givewp-font-size-headline-sm)',
+                        marginBottom: 'var(--givewp-spacing-2)',
+                    }}>{__('What is the Form Grid?', 'give')}</h3>
+                    <p>
+                        {__('The GiveWP Form Grid provides a way to add a grid layout of multiple forms into posts and pages using either a block or shortcode.', 'give')}
+                    </p>
+                    <ExternalLink href={'https://givewp.com/documentation/core/add-ons/form-grid/'}>{__('Learn more about the Form Grid', 'give')}</ExternalLink>
+                    <button style={{position: 'absolute', top: 'var(--givewp-spacing-4)', right: 'var(--givewp-spacing-4)'}}>Close</button>
+                </div>
+            )}
+
+        </PanelBody>
+    );
+};
+
+export default FormGridSettings;

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-grid/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-grid/index.tsx
@@ -1,6 +1,14 @@
 import {__} from '@wordpress/i18n';
-import {ExternalLink, PanelBody, PanelRow, TextControl, ToggleControl} from '@wordpress/components';
+import {
+    Button,
+    ExternalLink,
+    PanelBody,
+    PanelRow,
+    TextControl,
+    ToggleControl
+} from '@wordpress/components';
 import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
+import {closeSmall} from "@wordpress/icons";
 
 const FormGridSettings = () => {
     const {
@@ -57,7 +65,12 @@ const FormGridSettings = () => {
                         {__('The GiveWP Form Grid provides a way to add a grid layout of multiple forms into posts and pages using either a block or shortcode.', 'give')}
                     </p>
                     <ExternalLink href={'https://givewp.com/documentation/core/add-ons/form-grid/'}>{__('Learn more about the Form Grid', 'give')}</ExternalLink>
-                    <button style={{position: 'absolute', top: 'var(--givewp-spacing-4)', right: 'var(--givewp-spacing-4)'}}>Close</button>
+                    <Button
+                        icon={closeSmall}
+                        aria-label={__('Dismiss', 'give')}
+                        style={{position: 'absolute', top: 'var(--givewp-spacing-2)', right: 'var(--givewp-spacing-2)'}}
+                        onClick={() => dispatch(setFormSettings({formGridHideDocumentationLink: true}))}
+                    ></Button>
                 </div>
             )}
 

--- a/src/FormBuilder/resources/js/form-builder/src/settings/index.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/index.ts
@@ -5,6 +5,7 @@ import OfflineDonationsSettings from './offline-donation';
 import FormDesignSettings from './design';
 import CustomStyleSettings from './styles';
 import ReceiptSettings from './receipt';
+import FormGridSettings from './form-grid';
 import EmailSettings from './email';
 
 export {
@@ -15,5 +16,6 @@ export {
     FormDesignSettings,
     CustomStyleSettings,
     ReceiptSettings,
+    FormGridSettings,
     EmailSettings,
 };

--- a/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
@@ -30,4 +30,8 @@ export type FormSettings = {
     emailLogo: string;
     emailFromName: string;
     emailFromEmail: string;
+    formGridCustomize: boolean;
+    formGridRedirectUrl: string;
+    formGridDonateButtonText: string;
+    formGridHideDocumentationLink: boolean;
 };

--- a/src/FormMigration/Steps/FormGrid.php
+++ b/src/FormMigration/Steps/FormGrid.php
@@ -9,8 +9,9 @@ class FormGrid extends FormMigrationStep
 {
     public function process()
     {
-        $this->formV3->settings->formGridCustomized = $this->formV2->isFormGridCustomized();
+        $this->formV3->settings->formGridCustomize = $this->formV2->isFormGridCustomized();
         $this->formV3->settings->formGridRedirectUrl = $this->formV2->getFormGridRedirectUrl();
         $this->formV3->settings->formGridDonateButtonText = $this->formV2->getFormGridDonateButtonText();
+        $this->formV3->settings->formGridHideDocumentationLink = $this->formV2->isFormGridCustomized();
     }
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds the Form Grid settings to the Visual Donation Form Builder.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp-next-gen/assets/10858303/20373b64-0e54-4684-94ec-87567f44ff81)

![image](https://github.com/impress-org/givewp-next-gen/assets/10858303/c710f85e-a325-46da-92bf-bd76bbecb79f)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Toggle the form grid settings to be customized and add a redirect URL and a donate button text.