### PR TITLE
Fix: css small issues

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/logo-upload/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/logo-upload/index.tsx
@@ -40,21 +40,23 @@ export default ({value, onChange}) => {
         });
 
         // Finally, open the modal on click
-        frame.open()
-    }
+        frame.open();
+    };
     return (
-        <div style={{display: 'flex', flexDirection: 'column', gap: '10px', marginBottom: '8px'}}>
-            <div> {/* Wrapping the TextControl solves a spacing issue */}
-                <TextControl
-                    type={'url'}
-                    label={__('Logo URL', 'givewp')}
-                    value={value}
-                    onChange={onChange}
-                />
+        <div style={{display: 'flex', flexDirection: 'column', marginBottom: '8px', width: '100%'}}>
+            <div>
+                {' '}
+                {/* Wrapping the TextControl solves a spacing issue */}
+                <TextControl type={'url'} label={__('Logo URL', 'givewp')} value={value} onChange={onChange} />
             </div>
-            <Button icon={upload} variant={'secondary'} onClick={openMediaLibrary} style={{width:'100%', justifyContent:'center'}}>
+            <Button
+                icon={upload}
+                variant={'secondary'}
+                onClick={openMediaLibrary}
+                style={{width: '100%', justifyContent: 'center', marginBottom: '8px'}}
+            >
                 {__('Add or upload file', 'givewp')}
             </Button>
         </div>
-    )
-}
+    );
+};

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
@@ -81,8 +81,16 @@ export default () => {
                         <>
                             <CloseButton label={__('Set and close', 'givewp')} onClick={closeModal} />
                             {/* Note: I tried extracting these to a wrapper component, but that broken focus due to re-renders. */}
-                            <div style={{ display: 'flex', gap: 'var(--givewp-spacing-10)', height: '100%', overflow: 'hidden', flex: 1}}>
-                                <div style={{ flex: '2'}}>
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    gap: 'var(--givewp-spacing-10)',
+                                    height: 'calc(100% - 1.5rem)',
+                                    overflow: 'hidden',
+                                    flex: 1,
+                                }}
+                            >
+                                <div style={{flex: '2'}}>
                                     <TabPanel
                                         className={'email-settings-modal-tabs'}
                                         orientation={'vertical' as 'horizontal' | 'vertical' | 'both'}
@@ -90,50 +98,64 @@ export default () => {
                                             return {
                                                 name: notification.id,
                                                 title: notification.title,
-                                            }
+                                            };
                                         })}
                                         initialTabName={emailNotifications[0].id}
                                         state={[selectedTab, setSelectedTab]}
                                     >
                                         {(tab) => (
-                                            <div style={{
-                                                height: '100%',
-                                                overflowX: 'hidden',
-                                                overflowY: 'scroll',
-                                                padding: '20px', // Adjust for scrollbar
-                                            }}>
-                                                <h2 style={{margin:0}}>Notification</h2>
+                                            <div
+                                                style={{
+                                                    height: '100%',
+                                                    overflowX: 'hidden',
+                                                    overflowY: 'auto',
+                                                    padding: '20px', // Adjust for scrollbar
+                                                }}
+                                            >
+                                                <h2 style={{margin: 0}}>Notification</h2>
                                                 <p></p>
                                                 <EmailTemplateSettings notification={tab.name} />
                                             </div>
                                         )}
                                     </TabPanel>
                                 </div>
-                                <div style={{
-                                    flex: '1',
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    gap: 'var(--givewp-spacing-6)',
-                                    paddingRight: '10px', // Adjust for overflow
-                                    visibility: 'enabled' === selectedNotificationStatus ? 'visible' : 'hidden',
-                                }}>
-                                    <div style={{flex:1}}>
+                                <div
+                                    style={{
+                                        flex: '1',
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        gap: 'var(--givewp-spacing-6)',
+                                        paddingRight: '10px', // Adjust for overflow
+                                        visibility: 'enabled' === selectedNotificationStatus ? 'visible' : 'hidden',
+                                    }}
+                                >
+                                    <div style={{flex: 1}}>
                                         <h2 style={{margin: 0}}>{__('Preview email', 'givewp')}</h2>
-                                        <p>{__('Specify below the email address you want to send a test email to', 'givewp')}</p>
+                                        <p>
+                                            {__(
+                                                'Specify below the email address you want to send a test email to',
+                                                'givewp'
+                                            )}
+                                        </p>
                                         <Button
                                             variant={'secondary'}
-                                            style={{width:'100%',justifyContent:'center'}}
+                                            style={{width: '100%', justifyContent: 'center'}}
                                             onClick={() => setShowPreview(true)}
                                         >
                                             {__('Preview email', 'givewp')}
                                         </Button>
                                     </div>
-                                    <div style={{flex:1}}>
+                                    <div style={{flex: 1}}>
                                         <SendPreviewEmail emailType={selectedTab} />
                                     </div>
-                                    <div style={{flex:3}}>
+                                    <div style={{flex: 3}}>
                                         <h2 style={{margin: 0}}>{__('Template tags', 'givewp')}</h2>
-                                        <p>{__('Available template tags for this email. HTML is accepted. See our documentation for examples of how to use custom meta email tags to output additional donor or donation information in your GiveWP emails', 'givewp')}</p>
+                                        <p>
+                                            {__(
+                                                'Available template tags for this email. HTML is accepted. See our documentation for examples of how to use custom meta email tags to output additional donor or donation information in your GiveWP emails',
+                                                'givewp'
+                                            )}
+                                        </p>
                                         <ul className={'email-template-tags'}>
                                             {emailTemplateTags.map((tag) => (
                                                 <li key={tag.tag}>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
@@ -85,7 +85,7 @@ export default () => {
                                 style={{
                                     display: 'flex',
                                     gap: 'var(--givewp-spacing-10)',
-                                    height: 'calc(100% - 1.5rem)',
+                                    height: '100%',
                                     overflow: 'hidden',
                                     flex: 1,
                                 }}

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_email-settings.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_email-settings.scss
@@ -16,9 +16,14 @@
         &.is-active {
             background-color: var(--givewp-grey-25);
         }
+
         &:after {
             background: initial; // Remove the underline.
         }
+    }
+
+    .components-button {
+        text-align: left;
     }
 }
 

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
@@ -69,10 +69,6 @@
         font-weight: 500;
     }
 
-    .components-panel__row {
-        margin-right: 10px; // Account for scrollbar
-    }
-
     > .components-panel {
         border-left: 0;
         border-right: 0;


### PR DESCRIPTION
## Description

This PR address some really small CSS issues around the Email Notifications settings in the Form Builder.

## Affects

- Modal scrollbars
- Text alignment on modal tabs
- Margins of the Logo URL field

## Visuals
Before:
![CleanShot 2023-07-21 at 18 37 07](https://github.com/impress-org/givewp-next-gen/assets/3921017/f08b01e1-4334-46ef-9f60-165a84ea4eec)
![CleanShot 2023-07-21 at 18 36 53](https://github.com/impress-org/givewp-next-gen/assets/3921017/b3cbc3f4-471d-4c62-8b06-e4a4477a20f0)
![CleanShot 2023-07-21 at 18 36 28](https://github.com/impress-org/givewp-next-gen/assets/3921017/7f128225-816a-43b7-8280-d48d6c05834d)

After:
![CleanShot 2023-07-21 at 18 35 51](https://github.com/impress-org/givewp-next-gen/assets/3921017/73d682ab-d4f3-4ef5-a40e-333fcec89dc4)
![CleanShot 2023-07-21 at 18 35 14](https://github.com/impress-org/givewp-next-gen/assets/3921017/3b1619ed-f2fc-401f-b438-5aa4b7aa51e0)
![CleanShot 2023-07-21 at 18 34 34](https://github.com/impress-org/givewp-next-gen/assets/3921017/908fdfc5-2f4f-42e1-93f5-d83cf4f903d5)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

