### PR TITLE
Fix: Adjust media frame index to allow media-close-button to be clicked

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_email-settings.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_email-settings.scss
@@ -16,6 +16,7 @@
         &.is-active {
             background-color: var(--givewp-grey-25);
         }
+
         &:after {
             background: initial; // Remove the underline.
         }
@@ -34,6 +35,7 @@
     border: 1px solid var(--givewp-grey-100);
 
     scroll-snap-type: y mandatory;
+
     & > li {
         scroll-snap-align: start;
     }
@@ -45,6 +47,7 @@
         &:hover button {
             visibility: visible;
         }
+
         button {
             visibility: hidden;
             position: absolute;
@@ -69,4 +72,8 @@
 
 [id^='__wp-uploader'] {
     z-index: 9999999999;
+}
+
+.media-frame {
+    z-index: 1 !important;
 }


### PR DESCRIPTION
## Description

A style applied to the wp-uploader ```[id^='__wp-uploader'] {
    z-index: 9999999999;
}``` is being inherited by the media-frame class which covers the entire frame. 

I applied a z-index to the media frame to allow the button to be clicked again.

## Affects

Email Media Frame

## Visuals

https://github.com/impress-org/givewp-next-gen/assets/75056371/7db29f1b-b192-4de9-9217-e4d16fa77ad0

## Testing Instructions

- Under Form settings select Email settings.
- Select add or upload file.
- Close the but media frame with the close button on the top right.
- 
- ## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

