### PR TITLE
Feature: Offline Donation Instruction settings

### DIFF
--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -147,6 +147,16 @@ class FormSettings implements Arrayable, Jsonable
     public $formGridHideDocumentationLink;
 
     /**
+     * @var boolean
+     */
+    public $offlineDonationsCustomize;
+
+    /**
+     * @var string
+     */
+    public $offlineDonationsInstructions;
+
+    /**
      * @since 0.1.0
      */
     public static function fromArray(array $array): self
@@ -202,6 +212,10 @@ class FormSettings implements Arrayable, Jsonable
         $self->emailFromEmail = $array['emailFromEmail'] ?? '';
 
         $self->emailLogo = $array['emailLogo'] ?? '';
+
+        $self->offlineDonationsCustomize = $array['offlineDonationsCustomize'] ?? false;
+
+        $self->offlineDonationsInstructions = $array['offlineDonationsInstructions'] ?? '';
 
         return $self;
     }

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Primary/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Primary/index.tsx
@@ -12,6 +12,7 @@ import {
     ReceiptSettings,
     RegistrationSettings,
     FormGridSettings,
+    OfflineDonationsSettings,
 } from '../../../settings';
 import {PopoutSlot} from '../popout';
 import {useEffect} from 'react';
@@ -43,7 +44,7 @@ const tabs = [
                 <FormGridSettings />
                 <EmailSettings />
                 {/*The settings below have not been implemented yet.*/}
-                {/*<OfflineDonationsSettings/>*/}
+                <OfflineDonationsSettings/>
             </>
         ),
     },

--- a/src/FormBuilder/resources/js/form-builder/src/settings/offline-donation/donation-instructions.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/offline-donation/donation-instructions.js
@@ -1,99 +1,60 @@
 import {useState} from 'react';
 import {useToggleState} from '../../hooks';
-import {Button} from '@wordpress/components';
-import Popout, {PopoutContainer} from '../../components/sidebar/popout';
-import {RichText} from '@wordpress/block-editor';
+import {BaseControl, Button, Modal, PanelRow} from '@wordpress/components';
+import {__} from "@wordpress/i18n";
+import Editor from "@givewp/form-builder/settings/email/template-options/components/editor";
+import {MenuIcon} from "@givewp/form-builder/blocks/fields/terms-and-conditions/Icon";
+import {setFormSettings, useFormState, useFormStateDispatch} from "@givewp/form-builder/stores/form-state";
 
 const DonationInstructions = () => {
-    const {state: showPopout, toggle: toggleShowPopout} = useToggleState();
 
-    const [content, setContent] = useState(`
-            <p>You can customize instructions in the form settings.</p>
-            <p>Please make checks payable to <strong>"{sitename}"</strong>.</p>
-            <p>Your donation is greatly appreciated!</p>
-        `);
+    const {
+        settings: {offlineDonationsInstructions},
+    } = useFormState();
+    const dispatch = useFormStateDispatch();
+
+    const {state: showPopout, toggle: toggleShowPopout} = useToggleState();
 
     return (
         <>
-            <div
-                style={{
-                    marginTop: '10px',
-                    width: '100%',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                }}
-            >
-                Donation Instructions
-                <Button onClick={toggleShowPopout} style={{color: 'white', backgroundColor: '#68BF6B'}}>
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-6 w-6"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth="2"
+            <PanelRow>
+                <BaseControl
+                    id={'offline-donation-instructions-text'}
+                    help={__('This is the actual text which the user will follow to make a donation.', 'give')}
+                >
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                        }}
                     >
-                        <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
-                        />
-                    </svg>
-                </Button>
-            </div>
+                        {__('Donation Instructions', 'give')}
+                        <Button
+                            style={{background: 'transparent', verticalAlign: 'center'}}
+                            variant={'primary'}
+                            onClick={toggleShowPopout}
+                        >
+                            <MenuIcon />
+                        </Button>
+                    </div>
+                </BaseControl>
+            </PanelRow>
             {showPopout && (
-                <Popout>
-                    <PopoutContainer>
-                        <div style={{width: '400px'}}>
-                            <header style={{padding: '15px 10px', borderBottom: '1px solid lightgray'}}>
-                                <h3 style={{margin: '0'}}>Donation Instructions</h3>
-                            </header>
-                            <div style={{padding: '10px', borderBottom: '1px solid lightgray'}}>
-                                <RichText
-                                    style={{
-                                        height: '200px',
-                                        maxHeight: '200px',
-                                        overflowY: 'scroll',
-                                        lineHeight: '1.6',
-                                    }}
-                                    multiline={true}
-                                    identifier="content"
-                                    tagName="p"
-                                    value={content}
-                                    onChange={setContent}
-                                    placeholder={'PLACEHOLDER TEXT'}
-                                />
-                            </div>
-                            <div
-                                style={{
-                                    display: 'flex',
-                                    gap: '20px',
-                                    padding: '10px',
-                                    borderBottom: '1px solid lightgray',
-                                }}
-                            >
-                                <span>Visual</span>
-                                <span>Text</span>
-                            </div>
-                            <div
-                                style={{
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    gap: '20px',
-                                    padding: '15px 10px',
-                                    borderBottom: '1px solid lightgray',
-                                }}
-                            >
-                                <div>Text Style</div>
-                                <div>Text Format</div>
-                                <div>Alignment</div>
-                                <div>List Style</div>
-                                <div>Insert</div>
-                            </div>
-                        </div>
-                    </PopoutContainer>
-                </Popout>
+                <Modal
+                    title={__('Donation Instructions', 'give')}
+                    onRequestClose={toggleShowPopout}
+                    style={{maxWidth: '35rem'}}
+                >
+                    <Editor
+                        value={offlineDonationsInstructions ?? `
+                            <p>You can customize instructions in the form settings.</p>
+                            <p>Please make checks payable to <strong>"{sitename}"</strong>.</p>
+                            <p>Your donation is greatly appreciated!</p>
+                        `}
+                        onChange={(offlineDonationsInstructions) => dispatch(setFormSettings({offlineDonationsInstructions}))}
+                    />
+                </Modal>
             )}
         </>
     );

--- a/src/FormBuilder/resources/js/form-builder/src/settings/offline-donation/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/offline-donation/index.js
@@ -5,7 +5,7 @@ import DonationInstructions from './donation-instructions';
 
 const OfflineDonationsSettings = () => {
     const {
-        settings: {enableOfflineDonations, enableBillingFields},
+        settings: {offlineDonationsCustomize},
     } = useFormState();
     const dispatch = useFormStateDispatch();
 
@@ -21,17 +21,6 @@ const OfflineDonationsSettings = () => {
             </PanelRow>
             {enableOfflineDonations && (
                 <>
-                    <PanelRow>
-                        <ToggleControl
-                            label={__('Enable Billing Fields', 'give')}
-                            help={__(
-                                "DThis option will enable the billing details section for this form's offline donation payment gateway. The fieldset will appear above the offline donation instructions.",
-                                'give'
-                            )}
-                            checked={enableBillingFields}
-                            onChange={() => dispatch(setFormSettings({enableBillingFields: !enableBillingFields}))}
-                        />
-                    </PanelRow>
                     <PanelRow>
                         <DonationInstructions />
                     </PanelRow>

--- a/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
@@ -34,4 +34,5 @@ export type FormSettings = {
     formGridRedirectUrl: string;
     formGridDonateButtonText: string;
     formGridHideDocumentationLink: boolean;
+    offlineDonationsCustomize: boolean;
 };

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -148,10 +148,11 @@ class FormMetaDecorator extends FormModelDecorator
         return give_get_meta( $this->form->id, '_give_agree_text', true );
     }
 
-    public function isOfflineDonationsEnabled()
+    public function isOfflineDonationsCustomized()
     {
         return give_is_setting_enabled(
-            give_get_meta( $this->form->id, '_give_customize_offline_donations', true )
+            give_get_meta( $this->form->id, '_give_customize_offline_donations', true ),
+            'custom'
         );
     }
 

--- a/src/FormMigration/Steps/OfflineDonations.php
+++ b/src/FormMigration/Steps/OfflineDonations.php
@@ -9,7 +9,7 @@ class OfflineDonations extends FormMigrationStep
 {
     public function canHandle(): bool
     {
-        return $this->formV2->isOfflineDonationsEnabled();
+        return $this->formV2->isOfflineDonationsCustomized();
     }
 
     public function process()


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR re-introduces the Offline Donation settings in the Visual Form Builder, which includes the Donation Instructions text editor.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp-next-gen/assets/10858303/bd0bb41c-7fd6-4725-a132-8e19c2ced11c)

![image](https://github.com/impress-org/givewp-next-gen/assets/10858303/003d247c-835c-46f3-a5f3-b3bad90eecd5)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create (or migrate) a v3 donation form
- Enable customized offline donation settings
- Edit the offline donation instructions setting