### PR TITLE
Feature: "Redirect" migrated form IDs in shortcodes and blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "autoload": {
         "psr-4": {
             "Give\\": "src/"
-        }
+        },
+        "files": ["src/FormMigration/functions.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/FormMigration/functions.php
+++ b/src/FormMigration/functions.php
@@ -1,0 +1,28 @@
+<?php
+
+use Give\Framework\Database\DB;
+
+/**
+ * This function is used to "redirect" shortcodes and blocks
+ * to a migrated form ID, if one exists.
+ *
+ * @unreleased
+ *
+ * @param $formId $formId is used as an "output argument", meaning it is updated without needing to be returned.
+ *
+ * @return void Note: $formId is an "output argument" - not a return value.
+ */
+function givewp_migrated_form_id(&$formId) {
+    global $wpdb;
+
+    $formId = DB::get_var(
+        DB::prepare(
+            "
+                    SELECT `form_id`
+                    FROM `{$wpdb->prefix}give_formmeta`
+                    WHERE `meta_key` = 'migratedFormId'
+                      AND `meta_value` = %d",
+            $formId
+        )
+    ) ?: $formId;
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR hooks into shortcodes and block to "redirect" old (v2) form IDs to the new (v3) migrated form IDs.

With a single line the `$formId` can be updated to the migrated form ID:

```php
givewp_migrated_form_id($formId);
```

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The GiveWP (core) plugin will need to be updated in each location that a Form ID is specified as a shortcode or block argument.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

```diff
add_shortcode('give_example', function($atts) {
    $formId = absint( $atts['id'] );
+   givewp_migrated_form_id($formId);
    echo $formId;
});
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

