### PR TITLE
Feature: throw name collision exception during form builder update

### DIFF
--- a/src/DonationForms/Models/DonationForm.php
+++ b/src/DonationForms/Models/DonationForm.php
@@ -12,6 +12,7 @@ use Give\Framework\Blocks\BlockCollection;
 use Give\Framework\Exceptions\Primitives\Exception;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\FieldsAPI\DonationForm as Form;
+use Give\Framework\FieldsAPI\Exceptions\NameCollisionException;
 use Give\Framework\Models\Contracts\ModelCrud;
 use Give\Framework\Models\Contracts\ModelHasFactory;
 use Give\Framework\Models\Model;
@@ -131,8 +132,9 @@ class DonationForm extends Model implements ModelCrud, ModelHasFactory
 
     /**
      *
-     * @unreleased return DonationForm node
+     * @unreleased return DonationForm node; throw NameCollisionException
      * @since 0.1.0
+     * @throws NameCollisionException
      */
     public function schema(): Form
     {

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -12,6 +12,7 @@ use Give\Framework\Database\DB;
 use Give\Framework\Exceptions\Primitives\Exception;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\FieldsAPI\DonationForm as DonationFormNode;
+use Give\Framework\FieldsAPI\Exceptions\NameCollisionException;
 use Give\Framework\FieldsAPI\Hidden;
 use Give\Framework\FieldsAPI\Section;
 use Give\Framework\Models\ModelQueryBuilder;
@@ -400,9 +401,10 @@ class DonationFormRepository
     }
 
     /**
-     * @unreleased return DonationFormNode
+     * @unreleased return DonationFormNode; throw NameCollisionException
      * @since 0.4.0 append formId to first section instead of last with multistep in mind.
      * @since 0.1.0
+     * @throws NameCollisionException
      */
     public function getFormSchemaFromBlocks(int $formId, BlockCollection $blocks): DonationFormNode
     {
@@ -427,9 +429,11 @@ class DonationFormRepository
                         )
                 );
             }
+        } catch (NameCollisionException $exception) {
+            throw $exception;
         } catch (Exception $exception) {
             Log::error('Failed converting donation form blocks to fields', compact('formId', 'blocks'));
-            
+
             $form = new DonationFormNode('donation-form');
         }
 

--- a/src/FormBuilder/Controllers/FormBuilderResourceController.php
+++ b/src/FormBuilder/Controllers/FormBuilderResourceController.php
@@ -86,7 +86,8 @@ class FormBuilderResourceController
                     400,
                     sprintf(
                         __("A field name with meta key '%s' already exists. Please try a new one.", 'give'),
-                        $e->getNodeNameCollision()
+                        //TODO update with $e->getNodeNameCollision()
+                        str_replace("Node name collision for ", '', $e->getMessage())
                     )
                 )
             );

--- a/src/FormBuilder/Controllers/FormBuilderResourceController.php
+++ b/src/FormBuilder/Controllers/FormBuilderResourceController.php
@@ -86,8 +86,7 @@ class FormBuilderResourceController
                     400,
                     sprintf(
                         __("ERROR: the form was not saved due to a meta key name conflict. A field already exists on this form with the meta key '%s'. Meta key names must be unique. Change the conflicting meta key and try to save again. ", 'give'),
-                        //TODO update with $e->getNodeNameCollision()
-                        str_replace("Node name collision for ", '', $e->getMessage())
+                        $e->getNodeNameCollision()
                     )
                 )
             );

--- a/src/FormBuilder/Controllers/FormBuilderResourceController.php
+++ b/src/FormBuilder/Controllers/FormBuilderResourceController.php
@@ -85,7 +85,7 @@ class FormBuilderResourceController
                 new WP_Error(
                     400,
                     sprintf(
-                        __("A field name with meta key '%s' already exists. Please try a new one.", 'give'),
+                        __("ERROR: the form was not saved due to a meta key name conflict. A field already exists on this form with the meta key '%s'. Meta key names must be unique. Change the conflicting meta key and try to save again. ", 'give'),
                         //TODO update with $e->getNodeNameCollision()
                         str_replace("Node name collision for ", '', $e->getMessage())
                     )


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Depends on: https://github.com/impress-org/givewp/pull/6864

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
This catches a NameCollisionException from the form schema and responds to the client with a valuable message.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
The form builder update processing.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1129" alt="Screenshot 2023-08-07 at 1 20 29 PM" src="https://github.com/impress-org/givewp-next-gen/assets/10138447/83b64ee3-6236-4ca9-9fb9-30054e482772">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure GiveWP is `>=` https://github.com/impress-org/givewp/pull/6864

Try updating a custom field name with a reserved or existing programmatic name.  You should see an exception message.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

