### PR TITLE
Feature: Add action hook to when a block is converted to a node

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -96,11 +96,12 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
+     * @unlreased add `givewp_donation_form_block_converted` action hook
      * @since 0.1.0
      *
-     * @return Node|null
      * @throws EmptyNameException|NameCollisionException
      *
+     * @return Node|null
      */
     protected function convertInnerBlockToNode(BlockModel $block, int $blockIndex)
     {

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -26,6 +26,7 @@ use Give\Framework\FieldsAPI\PaymentGateways;
 use Give\Framework\FieldsAPI\Section;
 use Give\Framework\FieldsAPI\Text;
 use Give\Framework\FieldsAPI\Textarea;
+use Give\Helpers\Hooks;
 use WP_User;
 
 /**
@@ -106,7 +107,11 @@ class ConvertDonationFormBlocksToFieldsApi
         $node = $this->createNodeFromBlockWithUniqueAttributes($block, $blockIndex);
 
         if ($node instanceof Node) {
-            return $this->mapGenericBlockAttributesToNode($node, $block);
+            $node = $this->mapGenericBlockAttributesToNode($node, $block);
+
+            Hooks::doAction('givewp_donation_form_block_converted', $node, $block);
+
+            return $node;
         }
 
         return null;

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -96,7 +96,7 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
-     * @unlreased add `givewp_donation_form_block_converted` action hook
+     * @unlreased add `givewp_donation_form_block_converted_to_node` action hook
      * @since 0.1.0
      *
      * @throws EmptyNameException|NameCollisionException
@@ -110,7 +110,7 @@ class ConvertDonationFormBlocksToFieldsApi
         if ($node instanceof Node) {
             $node = $this->mapGenericBlockAttributesToNode($node, $block);
 
-            Hooks::doAction('givewp_donation_form_block_converted', $node, $block);
+            Hooks::doAction('givewp_donation_form_block_converted_to_node', $node, $block);
 
             return $node;
         }


### PR DESCRIPTION
## Description

This PR adds a new action hook `givewp_donation_form_block_converted_to_node` whenever a block is converted to a node. This new hook will allow us to create a relationship between blocks and nodes in FFM.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

